### PR TITLE
Add local Arduino build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ MedianFilterLib2
 
 Ctl+Shift+U for firmware upload using USBasp
 
+## Building Arduino firmware on Ubuntu
+
+This repository includes a helper script for compiling the Atmega2560
+firmware using the [Arduino CLI](https://arduino.github.io/arduino-cli/).
+The script will download the CLI tool if it is missing and build all
+available configuration variants.
+
+```bash
+sudo apt-get update && sudo apt-get install -y curl
+./scripts/build_arduino.sh
+```
+
+Build artifacts for each variant will be placed inside the `build/`
+directory.
+
 ![Digifiz Replica](/images/digifiz_next_photo.jpg)
 
 Requirements for ESP32 version:

--- a/scripts/build_arduino.sh
+++ b/scripts/build_arduino.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Build Digifiz Replica Arduino firmware using Arduino CLI.
+# The script installs arduino-cli if it is not available and
+# then compiles all firmware variants.
+
+set -e
+
+REPO_DIR="$(dirname "$0")/.."
+cd "$REPO_DIR"
+
+# Ensure arduino-cli is available
+if ! command -v arduino-cli >/dev/null 2>&1; then
+    echo "arduino-cli not found; installing..." >&2
+    curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+    export PATH="$HOME/bin:$PATH"
+fi
+
+# Install/Update AVR core
+arduino-cli core update-index
+arduino-cli core install arduino:avr
+
+# Create basic arduino-cli config
+mkdir -p ~/.arduino15
+cat > ~/.arduino15/arduino-cli.yaml <<'CFG'
+board_manager:
+  additional_urls: []
+daemon:
+  port: "50051"
+logging:
+  file: ""
+  format: text
+  level: info
+metrics:
+  addr: ""
+  enabled: false
+sketchbook_path: "$HOME/Arduino"
+allow_unsafe_install: true
+CFG
+
+# Firmware variants to build
+VARIANTS=${VARIANTS:-"setup_audi_red setup_audi_green setup_g2 setup_g2_uk setup_g2_usa setup_g2_diesel"}
+
+ORIG=A2560_BoardR2/Digifiz/setup.h
+BACKUP="$ORIG.orig"
+cp "$ORIG" "$BACKUP" 2>/dev/null || true
+mkdir -p build
+
+for VAR in $VARIANTS; do
+    echo "Building $VAR..."
+    cp "A2560_BoardR2/Digifiz/${VAR}.h" "$ORIG"
+    arduino-cli compile --fqbn arduino:avr:mega A2560_BoardR2/Digifiz/ --output-dir "build/$VAR"
+    echo "Finished $VAR"
+done
+
+mv "$BACKUP" "$ORIG"
+
+echo "Build artifacts located in ./build/"


### PR DESCRIPTION
## Summary
- add `scripts/build_arduino.sh` for compiling the Arduino firmware
- document local build instructions in README

## Testing
- `./scripts/build_arduino.sh` *(fails: 403 when downloading arduino-cli)*

------
https://chatgpt.com/codex/tasks/task_e_685a0cd821d8832383884102fbeabcb3