### PR TITLE
Add basic Catch2 tests for rpm filter

### DIFF
--- a/ESP32/Digifiz/main/CMakeLists.txt
+++ b/ESP32/Digifiz/main/CMakeLists.txt
@@ -7,7 +7,7 @@ idf_component_register(SRCS "mjs.c" "vehicle_data.c" "digifiz_time.c" "digifiz_w
 "adc.c" 
 "display_next.c" 
 "main.c" 
-"tacho.c" 
+"rpm_filter.c" "tacho.c" 
 "speedometer.c"
 INCLUDE_DIRS "."
 REQUIRES  

--- a/ESP32/Digifiz/main/rpm_filter.c
+++ b/ESP32/Digifiz/main/rpm_filter.c
@@ -1,0 +1,35 @@
+#include "rpm_filter.h"
+
+void init_buffer(CircularBuffer *buffer) {
+    for (int i = 0; i < RPM_WINDOW_SIZE; i++) {
+        buffer->data[i] = 0;
+    }
+    buffer->index = 0;
+}
+
+void insert_buffer(CircularBuffer *buffer, int value) {
+    buffer->data[buffer->index] = value;
+    buffer->index = (buffer->index + 1) % RPM_WINDOW_SIZE;
+}
+
+int find_median(CircularBuffer *buffer) {
+    int sorted[RPM_WINDOW_SIZE];
+    for (int i = 0; i < RPM_WINDOW_SIZE; i++) {
+        sorted[i] = buffer->data[i];
+    }
+    for (int i = 1; i < RPM_WINDOW_SIZE; i++) {
+        int key = sorted[i];
+        int j = i - 1;
+        while (j >= 0 && sorted[j] > key) {
+            sorted[j + 1] = sorted[j];
+            j = j - 1;
+        }
+        sorted[j + 1] = key;
+    }
+    return sorted[RPM_WINDOW_SIZE / 2];
+}
+
+int median_filter(CircularBuffer *buffer, int new_value) {
+    insert_buffer(buffer, new_value);
+    return find_median(buffer);
+}

--- a/ESP32/Digifiz/main/rpm_filter.h
+++ b/ESP32/Digifiz/main/rpm_filter.h
@@ -1,0 +1,17 @@
+#ifndef RPM_FILTER_H
+#define RPM_FILTER_H
+#include <stdint.h>
+
+#define RPM_WINDOW_SIZE 8
+
+typedef struct {
+    uint32_t data[RPM_WINDOW_SIZE];
+    uint8_t index;
+} CircularBuffer;
+
+void init_buffer(CircularBuffer *buffer);
+void insert_buffer(CircularBuffer *buffer, int value);
+int find_median(CircularBuffer *buffer);
+int median_filter(CircularBuffer *buffer, int new_value);
+
+#endif // RPM_FILTER_H

--- a/ESP32/Digifiz/main/tacho.c
+++ b/ESP32/Digifiz/main/tacho.c
@@ -19,49 +19,6 @@ static uint32_t buf_intv_q = 0;
 
 CircularBuffer rpm_buffer;
 
-// Initialize the circular buffer
-void init_buffer(CircularBuffer *buffer) {
-    for (int i = 0; i < RPM_WINDOW_SIZE; i++) {
-        buffer->data[i] = 0;
-    }
-    buffer->index = 0;
-}
-
-// Insert a new value into the circular buffer
-void insert_buffer(CircularBuffer *buffer, int value) {
-    buffer->data[buffer->index] = value;
-    buffer->index = (buffer->index + 1) % RPM_WINDOW_SIZE;
-}
-
-// Function to find the median of the buffer's data
-int find_median(CircularBuffer *buffer) {
-    int sorted[RPM_WINDOW_SIZE];
-    for (int i = 0; i < RPM_WINDOW_SIZE; i++) {
-        sorted[i] = buffer->data[i];
-    }
-    
-    // Sort the window (Insertion sort)
-    for (int i = 1; i < RPM_WINDOW_SIZE; i++) {
-        int key = sorted[i];
-        int j = i - 1;
-
-        while (j >= 0 && sorted[j] > key) {
-            sorted[j + 1] = sorted[j];
-            j = j - 1;
-        }
-        sorted[j + 1] = key;
-    }
-    
-    // Return the median element
-    return sorted[RPM_WINDOW_SIZE / 2];
-}
-
-// Median filter function
-int median_filter(CircularBuffer *buffer, int new_value) {
-    insert_buffer(buffer, new_value);
-    return find_median(buffer);
-}
-
 
 static void IRAM_ATTR gpio_isr_handler(void* arg) {    
     uint64_t current_time;

--- a/ESP32/Digifiz/main/tacho.h
+++ b/ESP32/Digifiz/main/tacho.h
@@ -14,14 +14,8 @@
 #include "freertos/queue.h"
 
 #define RPM_PIN 35
+#include "rpm_filter.h"
 #define DEBOUNCE_TICKS 500 //0.5ms
-#define RPM_WINDOW_SIZE 8  // Adjust as needed for your application
-
-// Circular buffer to hold the most recent data points
-typedef struct {
-    uint32_t data[RPM_WINDOW_SIZE];
-    uint8_t index;
-} CircularBuffer;
 
 /**
  * @brief Inits tacho module

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project(rpm_filter_tests C CXX)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(rpm_filter STATIC ../ESP32/Digifiz/main/rpm_filter.c)
+
+add_executable(rpm_filter_tests rpm_filter_test.cpp)
+
+target_include_directories(rpm_filter_tests PRIVATE .. ../ESP32/Digifiz/main ${CMAKE_CURRENT_LIST_DIR})
+
+target_link_libraries(rpm_filter_tests rpm_filter)

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -1,0 +1,56 @@
+#ifndef CATCH_HPP
+#define CATCH_HPP
+#include <vector>
+#include <functional>
+#include <string>
+#include <iostream>
+#include <stdexcept>
+
+struct CatchTestCase {
+    const char* name;
+    std::function<void()> func;
+};
+
+inline std::vector<CatchTestCase>& catchTests() {
+    static std::vector<CatchTestCase> tests;
+    return tests;
+}
+
+struct CatchAutoReg {
+    CatchAutoReg(const char* name, std::function<void()> func) {
+        catchTests().push_back({name, func});
+    }
+};
+
+#define CATCH_INTERNAL_TEST2(counter, name) \
+    static void test_func_##counter(); \
+    static CatchAutoReg auto_reg_##counter(name, test_func_##counter); \
+    static void test_func_##counter()
+
+#define CATCH_INTERNAL_TEST(counter, name) CATCH_INTERNAL_TEST2(counter, name)
+
+#define TEST_CASE(name) CATCH_INTERNAL_TEST(__COUNTER__, name)
+
+#define REQUIRE(cond) \
+    do { if(!(cond)) { \
+        std::cerr << "FAILED: " << #cond << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        throw std::runtime_error("test failed"); \
+    } } while(0)
+
+#ifdef CATCH_CONFIG_MAIN
+int main() {
+    int failures = 0;
+    for(auto& t : catchTests()) {
+        try {
+            t.func();
+            std::cout << "PASSED: " << t.name << std::endl;
+        } catch(const std::exception& e) {
+            std::cerr << "FAILED: " << t.name << " - " << e.what() << std::endl;
+            failures++;
+        }
+    }
+    return failures;
+}
+#endif
+
+#endif // CATCH_HPP

--- a/tests/rpm_filter_test.cpp
+++ b/tests/rpm_filter_test.cpp
@@ -1,0 +1,41 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+extern "C" {
+#include "rpm_filter.h"
+}
+
+TEST_CASE("init_buffer initializes data") {
+    CircularBuffer b;
+    b.data[0] = 123;
+    init_buffer(&b);
+    for(int i=0;i<RPM_WINDOW_SIZE;i++) {
+        REQUIRE(b.data[i] == 0);
+    }
+    REQUIRE(b.index == 0);
+}
+
+TEST_CASE("insert_buffer updates index and data") {
+    CircularBuffer b;
+    init_buffer(&b);
+    insert_buffer(&b, 1);
+    REQUIRE(b.data[0] == 1);
+    REQUIRE(b.index == 1);
+    for(int i=0;i<RPM_WINDOW_SIZE-1;i++) {
+        insert_buffer(&b, i+2);
+    }
+    REQUIRE(b.index == 0);
+    insert_buffer(&b, 99);
+    REQUIRE(b.data[b.index==0?RPM_WINDOW_SIZE-1:b.index-1] == 99);
+}
+
+TEST_CASE("median_filter computes median") {
+    CircularBuffer b;
+    init_buffer(&b);
+    for(int i=1;i<=RPM_WINDOW_SIZE;i++) {
+        median_filter(&b, i);
+    }
+    // After inserting 1..8, median should be 5
+    REQUIRE(find_median(&b) == 5);
+    int m = median_filter(&b, 9); // window now 9,2..8
+    REQUIRE(m == 6);
+}


### PR DESCRIPTION
## Summary
- refactor tacho buffer helpers into independent `rpm_filter` module
- expose new `rpm_filter` API
- add minimal Catch2 header and example tests
- provide CMake for building tests

## Testing
- `cmake -S tests -B tests/build`
- `cmake --build tests/build`
- `tests/build/rpm_filter_tests`

------
https://chatgpt.com/codex/tasks/task_e_685a0cb073708323b8ad01a95325d5e9