### PR TITLE
Add guide for custom color schemes

### DIFF
--- a/COLOR_SCHEMES.md
+++ b/COLOR_SCHEMES.md
@@ -1,0 +1,46 @@
+# Custom Color Schemes
+
+## English
+1. Power the Digifiz Replica and connect to its Wi-Fi access point. The default address is `http://192.168.4.1`.
+2. In the web dashboard open the **Settings** tab, press **Load Parameters**, enable **Custom scheme** (disabled by default) and save the parameters.
+3. Switch to the **Colors** tab.
+   - Use the main and backlight color pickers to choose base colors.
+   - Add or adjust rows in the **Color Scheme Editor** table for each LED range.
+4. Click **Set Scheme** to store the scheme in NVS so it persists across reboots.
+5. Use **Reset Scheme** or send `reset_colors` over serial to restore the factory scheme.
+
+## Русский
+1. Включите Digifiz Replica и подключитесь к её точке доступа Wi‑Fi. Адрес по умолчанию: `http://192.168.4.1`.
+2. В веб‑интерфейсе откройте вкладку **Settings**, нажмите **Load Parameters**, включите **Custom scheme** (по умолчанию выключено) и сохраните параметры.
+3. Перейдите на вкладку **Colors**.
+   - Выберите основные цвета с помощью цветовых пиков.
+   - Добавляйте или изменяйте строки в таблице **Color Scheme Editor** для каждого диапазона светодиодов.
+4. Нажмите **Set Scheme**, чтобы записать схему в NVS и сохранить её после перезагрузки.
+5. Кнопка **Reset Scheme** или команда `reset_colors` возвращает заводские цвета.
+
+## Magyar
+1. Kapcsold be a Digifiz Replicát és csatlakozz a Wi‑Fi hozzáférési pontjához. Az alapértelmezett cím: `http://192.168.4.1`.
+2. A webes felületen nyisd meg a **Settings** lapot, kattints a **Load Parameters** gombra, engedélyezd a **Custom scheme** opciót (alapból kikapcsolva) és mentsd el a paramétereket.
+3. Válts a **Colors** lapra.
+   - A fő- és háttérszín kiválasztásához használd a színválasztókat.
+   - A **Color Scheme Editor** táblázatban adj hozzá vagy módosíts szegmenseket minden LED tartományhoz.
+4. A **Set Scheme** gombbal mentsd a sémát az NVS-be, így újraindítás után is megmarad.
+5. A **Reset Scheme** gomb vagy a `reset_colors` parancs visszaállítja a gyári színeket.
+
+## Deutsch
+1. Schalte die Digifiz Replica ein und verbinde dich mit ihrem WLAN-Access-Point. Standardadresse: `http://192.168.4.1`.
+2. Öffne im Webinterface den Reiter **Settings**, klicke auf **Load Parameters**, aktiviere **Custom scheme** (standardmäßig aus) und speichere die Parameter.
+3. Wechsle zum Reiter **Colors**.
+   - Wähle Grundfarben über die Farbwahlschaltflächen.
+   - Füge im **Color Scheme Editor**-Tabelle Segmente für jeden LED-Bereich hinzu oder passe sie an.
+4. Speichere die Einstellungen mit **Set Scheme**; das Schema wird in der NVS abgelegt und bleibt nach Neustarts erhalten.
+5. Mit **Reset Scheme** oder dem Befehl `reset_colors` lässt sich die Werksschemata wiederherstellen.
+
+## Español
+1. Enciende la Digifiz Replica y conéctate a su punto de acceso Wi‑Fi. La dirección por defecto es `http://192.168.4.1`.
+2. En la interfaz web abre la pestaña **Settings**, pulsa **Load Parameters**, activa **Custom scheme** (desactivado por defecto) y guarda los parámetros.
+3. Ve a la pestaña **Colors**.
+   - Usa los selectores de color principal y de fondo para elegir los tonos base.
+   - Añade o modifica filas en la tabla **Color Scheme Editor** para cada tramo de LED.
+4. Presiona **Set Scheme** para guardar la configuración en la NVS y mantenerla tras reinicios.
+5. El botón **Reset Scheme** o el comando `reset_colors` restaura los colores de fábrica.


### PR DESCRIPTION
## Summary
- document how to use the ESP32 web dashboard to set up custom LED color schemes
- explain that the dashboard runs at http://192.168.4.1 and the custom scheme must be enabled on the Settings tab before editing colors
- provide step-by-step instructions in English, Russian, Hungarian, German and Spanish

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_688d80d4f98c83239ef06f17655abe6f