### PR TITLE
Add 7k RPM display option

### DIFF
--- a/ESP32/Digifiz/main/display_next.c
+++ b/ESP32/Digifiz/main/display_next.c
@@ -974,6 +974,15 @@ static void getColorBySegmentNumber(ColoringScheme* c_ptr, uint16_t segment, uin
             {
                 //TODO refactor this code to some js script executed on boot 
                 //or load data completely from memory (calculate on computer side)
+                if (digifiz_parameters.rpmOptions_7k_line.value)
+                {
+                    if ((segment>76)&&(segment<=78))
+                    {
+                        (*r) = 0;
+                        (*g) = 0;
+                        (*b) = 0;
+                    }
+                }
                 if (digifiz_parameters.rpmOptions_diesel_line.value)
                 {
                     if ((segment>76)&&(segment<=80))

--- a/ESP32/Digifiz/main/params_list.h
+++ b/ESP32/Digifiz/main/params_list.h
@@ -139,6 +139,14 @@ extern "C" {
     ) \
     PARAM(  \
         U8, \
+        rpmOptions_7k_line, \
+        .p_name = "7k option", \
+        .p_info = "7k-style RPM gauge",\
+        .value = 0, \
+        .max = 1, \
+    ) \
+    PARAM(  \
+        U8, \
         tempOptions_red_segments, \
         .p_name = "Red segments count", \
         .p_info = "Temperature red segments count",\

--- a/ESP32/Digifiz/main/protocol.c
+++ b/ESP32/Digifiz/main/protocol.c
@@ -480,6 +480,7 @@ void processData(int parameter,long value)
         printLnCString("PARAMETER_SET_RPM_OPTIONS\n");
         digifiz_parameters.rpmOptions_redline_segments.value = value&31;
         digifiz_parameters.rpmOptions_diesel_line.value = value&32;
+        digifiz_parameters.rpmOptions_7k_line.value = value&64;
         break;
       case PARAMETER_SET_TEMP_OPTIONS:
         printLnCString("PARAMETER_SET_TEMP_OPTIONS\n");


### PR DESCRIPTION
## Summary
- add configurable 7k RPM gauge option
- parse 7k flag in protocol
- hide higher RPM digits when 7k option is enabled

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eb9739adc8323bc962b2dbea79ab9