### PR TITLE
Delay MFA button handling during first 3 seconds after boot

### DIFF
--- a/A2560_BoardR2/Digifiz/mfa.cpp
+++ b/A2560_BoardR2/Digifiz/mfa.cpp
@@ -36,6 +36,15 @@ void initMFA()
 
 void processMFA()
 {
+    // Block MFA inputs shortly after boot to avoid unintended actions
+    if (millis() < 3000)
+    {
+        prevMFAMode = digitalRead(MFA_MODE_PIN);
+        prevMFABlock = digitalRead(MFA_BLOCK_PIN);
+        prevMFAReset = digitalRead(MFA_RESET_PIN);
+        prevMFASensor = digitalRead(MFA_SENSOR_PIN);
+        return;
+    }
 
 #ifndef DISABLE_MANUFACTURER_MFA
     if (digifiz_parameters.digifiz_options.mfa_manufacturer)

--- a/ESP32/Digifiz/main/mfa.c
+++ b/ESP32/Digifiz/main/mfa.c
@@ -55,7 +55,17 @@ void processMFA()
     {
         bMFASensor = 0;//gpio_get_level(TOUCH_PIN);
     }
-    
+
+    // Block MFA input actions shortly after boot to prevent spurious events
+    if (millis() < 3000)
+    {
+        prevMFAMode = bMFAMode;
+        prevMFABlock = bMFABlock;
+        prevMFAReset = bMFAReset;
+        prevMFASensor = bMFASensor;
+        return;
+    }
+
 #ifndef DISABLE_MANUFACTURER_MFA
     if (digifiz_parameters.option_mfa_manufacturer.value)
     {


### PR DESCRIPTION
## Summary
- Ignore MFA mode, block, and reset inputs for first three seconds after start to prevent unintended actions
- Apply boot-time MFA input block to both ESP32 and A2560 firmware variants

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899dd39bc748323847846dc34cc77d4