### PR TITLE
Disable empty color scheme updates and limit brightness level

### DIFF
--- a/ESP32/Digifiz/main/data/digifiz_ws_connect.html
+++ b/ESP32/Digifiz/main/data/digifiz_ws_connect.html
@@ -897,6 +897,11 @@ document.getElementById("defaultTab").click();
 
 <script>
 // Color scheme table management
+function updateSetColorSchemeButton() {
+    const rows = document.querySelectorAll('#colorSchemeTable tbody tr');
+    document.getElementById('setColorScheme').disabled = rows.length === 0;
+}
+
 function addColorSegmentRow(data = null) {
     const tbody = document.querySelector('#colorSchemeTable tbody');
     const row = document.createElement('tr');
@@ -1026,6 +1031,7 @@ function addColorSegmentRow(data = null) {
     deleteButton.onclick = function() {
         if (confirm('Are you sure you want to delete this segment?')) {
             row.remove();
+            updateSetColorSchemeButton();
         }
     };
 
@@ -1052,6 +1058,7 @@ function addColorSegmentRow(data = null) {
 
     // Append row to table
     tbody.appendChild(row);
+    updateSetColorSchemeButton();
 }
 
 document.getElementById('addColorSegment').addEventListener('click', function() {
@@ -1066,7 +1073,11 @@ document.getElementById("resetColorScheme").addEventListener("click", async func
 
 document.getElementById("setColorScheme").addEventListener("click", async function () {
     const rows = document.querySelectorAll('#colorSchemeTable tbody tr');
-	
+    if (rows.length === 0) {
+        alert("No color segments defined!");
+        return;
+    }
+
     let iter = 0;
 
     for (const row of rows) {
@@ -1129,6 +1140,7 @@ function loadColorScheme() {
             data.scheme.forEach(segment => {
                 addColorSegmentRow(segment);
             });
+            updateSetColorSchemeButton();
         })
         .catch(err => {
             console.error("Load failed:", err);
@@ -1182,6 +1194,7 @@ document.getElementById('importFile').addEventListener('change', function(e) {
                 scheme.forEach(segment => {
                     addColorSegmentRow(segment);
                 });
+                updateSetColorSchemeButton();
             } catch (err) {
                 alert('Error importing scheme: ' + err.message);
             }
@@ -1190,6 +1203,8 @@ document.getElementById('importFile').addEventListener('change', function(e) {
     }
     this.value = ''; // Reset file input
 });
+
+updateSetColorSchemeButton();
 </script>
 
 </body>

--- a/ESP32/Digifiz/main/params_list.h
+++ b/ESP32/Digifiz/main/params_list.h
@@ -327,6 +327,7 @@ extern "C" {
         .p_name = "Brightness level", \
         .p_info = "Manual brightness level.",\
         .value = 25, \
+        .max = 70, \
     ) \
     PARAM(  \
         U8, \

--- a/ESP32/Digifiz/main/protocol.c
+++ b/ESP32/Digifiz/main/protocol.c
@@ -375,7 +375,7 @@ void processData(int parameter,long value)
         break;
       case PARAMETER_BRIGHTNESS_LEVEL:
         printLnCString("PARAMETER_BRIGHTNESS_LEVEL\n");
-        digifiz_parameters.brightnessLevel.value = value;
+        digifiz_parameters.brightnessLevel.value = value > 70 ? 70 : value;
         break;
       case PARAMETER_TANK_CAPACITY:
         printLnCString("PARAMETER_TANK_CAPACITY\n");


### PR DESCRIPTION
## Summary
- Prevent submitting color scheme when no rows exist in the editor
- Cap manual/auto brightness parameter at 70 and clamp protocol updates

## Testing
- `idf.py --version` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc0550a5c832398717b7513cbaf41