### PR TITLE
docs(a2560): add Doxygen comments to core Digifiz headers

### DIFF
--- a/A2560_BoardR2/Digifiz/adc.h
+++ b/A2560_BoardR2/Digifiz/adc.h
@@ -4,24 +4,36 @@
 #include "Arduino.h"
 #include "ext_eeprom.h"
 
+/**
+ * @brief Initializes ADC channels, filters, and persisted calibration parameters.
+ */
 void initADC();
+
+/**
+ * @brief Reloads ADC conversion settings from persistent parameters.
+ */
 void updateADCSettings();
-//RAW values 0..1024
+/// @name Raw ADC helper accessors (0..1024)
+/// @{
 uint16_t getRawCoolantTemperature();
 uint16_t getRawOilTemperature();
 uint16_t getRawGasLevel();
 uint16_t getRawAmbientTemperature();
 uint16_t getRawLightLevel();
+/// @}
 
-//Display helpers
+/// @name Display-oriented helper values
+/// @{
 uint8_t getLitresInTank(); //0..99
 uint8_t getGallonsInTank(); //0..99
 uint8_t getDisplayedCoolantTemp(); //0..14
 uint8_t getDisplayedOilTemp(); //0..16
 uint8_t getDisplayedCoolantTempOrig(); //0..20
+/// @}
 
 
-//Physical data values
+/// @name Physical values converted from sensors
+/// @{
 float getCoolantTemperature(); //celsius
 float getOilTemperature(); //celsius
 float getGasLevel(float R); //percents
@@ -38,13 +50,20 @@ float getAmbientTemperatureFahrenheit(); //F
 
 uint8_t getBrightnessLevel();
 uint16_t getRawBrightnessLevel();
+/// @}
 
+/**
+ * @brief Updates all sensor filters with new samples.
+ */
 void processCoolantTemperature();
 void processOilTemperature();
 void processGasLevel();
 void processAmbientTemperature();
 void processBrightnessLevel();
 
+/**
+ * @brief Seeds filtering state on startup to avoid zero-biased values.
+ */
 void processFirstCoolantTemperature(); //to prevent filtering from zero value
 void processFirstOilTemperature();
 void processFirstGasLevel();

--- a/A2560_BoardR2/Digifiz/buzzer.h
+++ b/A2560_BoardR2/Digifiz/buzzer.h
@@ -7,12 +7,41 @@
 
 #define BUZZER_PIN 46 //PL3
 
+/**
+ * @brief Configures the buzzer GPIO and loads current user preference.
+ */
 void initBuzzer();
+
+/**
+ * @brief Forces the buzzer into a continuous ON state.
+ */
 void buzzerConstantOn();
+
+/**
+ * @brief Forces the buzzer into a continuous OFF state.
+ */
 void buzzerConstantOff();
+
+/**
+ * @brief Starts a short buzzer pulse according to firmware timing.
+ */
 void buzzerOn();
+
+/**
+ * @brief Stops an active buzzer pulse.
+ */
 void buzzerOff();
+
+/**
+ * @brief Returns whether buzzer notifications are enabled.
+ *
+ * @return uint8_t Non-zero if enabled, 0 if disabled.
+ */
 uint8_t getBuzzerEnabled();
+
+/**
+ * @brief Toggles persisted buzzer enable/disable state.
+ */
 void buzzerToggle();
 
 #endif

--- a/A2560_BoardR2/Digifiz/display.h
+++ b/A2560_BoardR2/Digifiz/display.h
@@ -71,26 +71,49 @@
 
 #define USE_DISPLAY_LEDS
 
+/**
+ * @brief Initializes display drivers, buffers, and startup animation state.
+ */
 void initDisplay(); 
+/// @brief Updates tachometer pointer/segments from engine RPM.
 void setRPM(int rpmdata);
+/// @brief Writes current time into the primary clock area.
 void setClockData(uint8_t clock_hours,uint8_t clock_minutes);
+/// @brief Writes current time into the MFA clock area.
 void setMFAClockData(uint8_t mfa_clock_hours,uint8_t mfa_clock_minutes);
+/// @brief Displays a signed numeric value on MFA segment area.
 void setMFADisplayedNumber(int16_t data);
+/// @brief Displays fuel quantity.
 void setFuel(uint8_t litres);
+/// @brief Displays raw RPM value digits.
 void setRPMData(uint16_t data);
+/// @brief Displays current vehicle speed digits.
 void setSpeedometerData(uint16_t data);
+/// @brief Displays coolant temperature indicator.
 void setCoolantData(uint16_t data);
+/// @brief Enables/disables the primary decimal separator.
 void setDot(bool value);
+/// @brief Enables/disables the auxiliary decimal separator.
 void setFloatDot(bool value);
+/// @brief Displays odometer mileage.
 void setMileage(uint32_t mileage);
+/// @brief Selects current MFA item type.
 void setMFAType(uint8_t mfaType);
+/// @brief Renders current MFA item type label/icon.
 void displayMFAType(uint8_t mfaType);
+/// @brief Selects current MFA block.
 void setMFABlock(uint8_t block);
+/// @brief Sets display brightness level.
 void setBrightness(uint8_t levels);
+/// @brief Shows/hides refuel indicator.
 void setRefuelSign(bool onoff);
+/// @brief Shows/hides check-engine indicator.
 void setCheckEngine(bool onoff);
+/// @brief Controls LCD/cluster backlight output.
 void setBacklight(bool onoff);
+/// @brief Displays service/status byte in service area.
 void setServiceDisplayData(uint8_t data);
+/// @brief Triggers display self-test/startup effect.
 void fireDigifiz();
 #endif
 #endif

--- a/A2560_BoardR2/Digifiz/mfa.h
+++ b/A2560_BoardR2/Digifiz/mfa.h
@@ -57,14 +57,49 @@
 #endif
 
 
+/**
+ * @brief Initializes MFA inputs, state machine, and persisted settings.
+ */
 void initMFA();
+
+/**
+ * @brief Processes MFA button/sensor state and updates active display mode.
+ */
 void processMFA();
+
+/**
+ * @brief Handles a short press on MFA mode button.
+ */
 void pressMFAMode();
+
+/**
+ * @brief Handles a short press on MFA block button.
+ */
 void pressMFABlock();
+
+/**
+ * @brief Handles a press on MFA reset button.
+ */
 void pressMFAReset();
+
+/**
+ * @brief Handles short touch-sensor interaction.
+ */
 void pressMFASensorShort();
+
+/**
+ * @brief Handles long touch-sensor interaction.
+ */
 void pressMFASensorLong();
+
+/**
+ * @brief Handles extra-long touch-sensor interaction.
+ */
 void pressMFASensorSuperLong();
+
+/**
+ * @brief Handles maximum-duration touch-sensor interaction.
+ */
 void pressMFASensorSuperSuperLong();
 
 #endif

--- a/A2560_BoardR2/Digifiz/protocol.h
+++ b/A2560_BoardR2/Digifiz/protocol.h
@@ -7,10 +7,18 @@
 #include "ext_eeprom.h"
 #include "setup.h"
 
-//0..64 normal parameters
-//128...128+64 read parameters
-//223..225 execute commands
+/**
+ * @file protocol.h
+ * @brief Serial/BLE command protocol declarations for Digifiz A2560 firmware.
+ */
 
+/// 0..64 normal parameters
+/// 128...128+64 read parameters
+/// 223..225 execute commands
+
+/**
+ * @brief Protocol parameter and command identifiers.
+ */
 typedef enum {
     PARAMETER_ZERO_RESERVED,       // 0
     PARAMETER_SPEEDCOEEFICIENT,     // 1
@@ -92,12 +100,44 @@ typedef enum {
     PARAMETER_TOGGLE_TOUCH_SENSOR = 229,
 } DigifizProtocol;
 
+/**
+ * @brief Initializes communication protocol parsers and command handlers.
+ */
 void initComProtocol();
+
+/**
+ * @brief Applies a persisted BLE name change command, if requested.
+ */
 void changeBLEName();
+
+/**
+ * @brief Parses inbound protocol frames and dispatches commands.
+ */
 void protocolParse();
+
+/**
+ * @brief Handles a single parameter write/command.
+ *
+ * @param par Protocol parameter identifier.
+ * @param value Value associated with the identifier.
+ */
 void processData(int par, long value);
+
+/**
+ * @brief Applies packed GPIO output bit values received over protocol.
+ *
+ * @param value Encoded GPIO state payload.
+ */
 void processGPIOPinsValue(long value);
+
+/**
+ * @brief Prints command help text to the active serial output.
+ */
 void printHelp();
+
+/**
+ * @brief Prints firmware/about information to the active serial output.
+ */
 void printAbout();
 
 #endif


### PR DESCRIPTION
### Motivation
- Provide Doxygen-style documentation for the A2560 Digifiz firmware headers to improve API discoverability and make it easier to generate reference docs.
- Clarify function intent, group related ADC accessors, and document protocol/display/MFA/buzzer interfaces for maintainability and future contributors.

### Description
- Add grouped Doxygen comments and `@brief` blocks in `A2560_BoardR2/Digifiz/adc.h` for initialization, raw ADC accessors, display helpers, converted physical values, and filter seeding/processing functions.
- Add full function-level Doxygen comments to `A2560_BoardR2/Digifiz/buzzer.h` documenting initialization, pulse controls, and persisted enable state accessors.
- Add concise `@brief` entries to `A2560_BoardR2/Digifiz/display.h` for display initialization and all display API functions (clock, RPM, MFA, indicators, brightness, etc.).
- Add Doxygen docs to `A2560_BoardR2/Digifiz/mfa.h` for MFA initialization, processing, and all button/touch interaction handlers, and add a file-level doc + enum/function docs to `A2560_BoardR2/Digifiz/protocol.h` for protocol identifiers and handlers.

### Testing
- Ran `git diff --check` to verify whitespace/format issues and it returned no errors.
- Verified staged changes with `git status --short` and reviewed the commit via `git show --stat --oneline HEAD`, both succeeding and showing the five modified headers.
- Committed changes with message `docs(a2560): add doxygen comments to core module headers` and created the PR metadata as part of the routine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da964b22948323aaf156f1f29ef041)