### PR TITLE
docs(esp32): expand doxygen coverage for header enums, defines, and APIs

### DIFF
--- a/ESP32/Digifiz/components/xparam/xparam.h
+++ b/ESP32/Digifiz/components/xparam/xparam.h
@@ -20,20 +20,35 @@
 #include <assert.h>
 #include <stdbool.h>
 
+/** @brief Magic marker used in serialized xparam images. */
 #define XPARAM_MAGIC 0xABCD1234
+/** @brief Enable verbose logging inside xparam module when non-zero. */
 #define XPARAM_LOG   1
 
 /* Exported types ------------------------------------------------------------*/
+/**
+ * @brief Supported storage types for xparam values.
+ */
 typedef enum{
+	/** @brief Uninitialized/invalid type marker. */
 	XPARAM_NONE,
+	/** @brief Boolean value (`bool`). */
 	XPARAM_BOOL,
+	/** @brief Signed 8-bit integer value. */
 	XPARAM_I8,
+	/** @brief Unsigned 8-bit integer value. */
 	XPARAM_U8,
+	/** @brief Signed 16-bit integer value. */
 	XPARAM_I16,
+	/** @brief Unsigned 16-bit integer value. */
 	XPARAM_U16,
+	/** @brief Signed 32-bit integer value. */
 	XPARAM_I32,
+	/** @brief Unsigned 32-bit integer value. */
 	XPARAM_U32,
+	/** @brief Floating-point value. */
 	XPARAM_FLOAT,
+	/** @brief Null-terminated C string pointer value. */
 	XPARAM_STRING,
 }xparam_vtype_t;
 
@@ -148,6 +163,11 @@ static_assert(	sizeof(xparam_header_t) == 16,
 static_assert(	sizeof(xparam_store_t)  == 16,
 		"changing xparam_store_t size will break already written parameters");
 
+/**
+ * @brief Compute serialized xparam image size for @p n entries.
+ *
+ * @param n Number of parameters serialized into the image.
+ */
 #define XPARAM_IMAGE_SIZE(n) (sizeof(xparam_img_t) + (n * sizeof(xparam_store_t)))
 
 /* Exported constants --------------------------------------------------------*/
@@ -173,7 +193,9 @@ static_assert(	sizeof(xparam_store_t)  == 16,
  * This macros get applied for each element in parameter list
  * _type can be one of: I8, U8, I16, U16, I32, U32, FLOAT, STRING
  */
+/** @brief Declare one xparam table field from x-macro list entry. */
 #define DECLARE_PARAM(_type, _name, ...) xparam_##_type##_t _name;
+/** @brief Define one xparam table initializer entry from x-macro list entry. */
 #define DEFINE_PARAM(_type, _name, ...) \
 		._name = {\
 			.value_type = XPARAM_##_type, \
@@ -184,6 +206,7 @@ static_assert(	sizeof(xparam_store_t)  == 16,
 /*
  * Macro to get count of parameters in a table
  */
+/** @brief Number of `xparam_t` records in static table object @p T. */
 #define XPARAM_COUNT(T) (sizeof(T) / sizeof(xparam_t))
 
 
@@ -194,16 +217,36 @@ static_assert(	sizeof(xparam_store_t)  == 16,
  * Get data blob from provided table, user needs to free returned pointer.
  * Could return NULL if malloc fails.
  */
+/**
+ * @brief Serialize xparam table to a binary blob.
+ *
+ * @param table Source parameter table.
+ * @return uint8_t* Heap-allocated blob, or NULL on allocation failure.
+ */
 uint8_t* xparam_table_to_blob(xparam_table_t* table);
 
 /*
  * Load table values from data blob.
  * Return 1 if table was found in blob, 0 if no table is found.
  */
+/**
+ * @brief Load xparam values from serialized binary blob.
+ *
+ * @param table Destination table to update.
+ * @param buf Serialized blob returned by storage/backend layer.
+ * @return uint8_t 1 if compatible table found and loaded, 0 otherwise.
+ */
 uint8_t  xparam_table_from_blob(xparam_table_t* table, uint8_t* buf);
 
 /*
  * Copy parameter value converted to string to provided buffer.
+ */
+/**
+ * @brief Convert one parameter value to human-readable string.
+ *
+ * @param param Parameter to convert.
+ * @param buf Destination output buffer.
+ * @return int Number of characters written to @p buf.
  */
 int 	 xparam_stringify(xparam_t* param, char* buf);
 
@@ -211,11 +254,25 @@ int 	 xparam_stringify(xparam_t* param, char* buf);
  * Increment/decrement parameter by number of steps.
  * Returns 0 if change would violate parameter limits and parameter value didn't change.
  */
+/**
+ * @brief Increment/decrement parameter by N steps.
+ *
+ * @param param Parameter to modify.
+ * @param n_steps Signed number of step increments.
+ * @return uint8_t 1 if value changed, 0 when clamped by limits.
+ */
 uint8_t  xparam_step_value(xparam_t* param, int16_t n_steps);
 
 /*
  * Set numeric value
  * Returns 0 if change would violate parameter limits and parameter value didn't change.
+ */
+/**
+ * @brief Set raw numeric value for a parameter.
+ *
+ * @param param Parameter to modify.
+ * @param value New raw value.
+ * @return uint8_t 1 if value accepted, 0 when rejected by limits.
  */
 uint8_t  xparam_set_value(xparam_t* param, uint32_t value);
 
@@ -223,10 +280,23 @@ uint8_t  xparam_set_value(xparam_t* param, uint32_t value);
  * Convert parameter table to json string.
  * User needs to free the returned pointer. Could return NULL if malloc fails.
  */
+/**
+ * @brief Serialize parameter table to JSON string.
+ *
+ * @param table Source table.
+ * @return char* Heap-allocated JSON string, or NULL on failure.
+ */
 char*    xparam_table_to_json(xparam_table_t* table);
 
 /*
  * Find xparam_t from table by name
+ */
+/**
+ * @brief Find parameter by its symbolic field name.
+ *
+ * @param table Table to search.
+ * @param name Field name string to match.
+ * @return xparam_t* Pointer to parameter on success, NULL if not found.
  */
 xparam_t* xparam_find_by_name(xparam_table_t* table, const char* name);
 

--- a/ESP32/Digifiz/main/digifiz_watchdog.h
+++ b/ESP32/Digifiz/main/digifiz_watchdog.h
@@ -1,43 +1,54 @@
 #ifndef DIGIFIZ_WATCHDOG_H
 #define DIGIFIZ_WATCHDOG_H
 
+/**
+ * @file digifiz_watchdog.h
+ * @brief Optional watchdog abstraction with no-op fallbacks.
+ */
+
 #include "esp_err.h"
 
-// Define this macro to enable watchdog functionality
+/** @brief Define to compile real watchdog implementation instead of no-op macros. */
 // #define WATCHDOG_ENABLED
 
 #ifdef WATCHDOG_ENABLED
 
-// Initializes the watchdog timer
+/** @brief Initialize watchdog timer resources. */
 esp_err_t watchdog_init(void);
 
-// Checks if the watchdog timer is currently running
+/** @brief Check whether watchdog is currently armed and running. */
 bool watchdog_is_running(void);
 
-// Updates (kicks) the watchdog timer to prevent a reset
+/** @brief Feed watchdog to prevent timeout reset. */
 void watchdog_update(void);
 
-// Deletes the watchdog timer (e.g., before entering deep sleep)
+/** @brief Deinitialize watchdog timer (for example before deep sleep). */
 void watchdog_delete(void);
 
-// Reinitializes the watchdog timer after deep sleep
+/** @brief Reinitialize watchdog after wake-up from deep sleep. */
 esp_err_t watchdog_reinit(void);
 
-// Creates a mutex for watchdog synchronization
+/** @brief Create synchronization primitive for watchdog access. */
 void watchdog_mutex_create(void);
 
-// Deletes the mutex for watchdog synchronization
+/** @brief Delete synchronization primitive created for watchdog access. */
 void watchdog_mutex_delete(void);
 
 #else
 
-// Define empty macros for the watchdog functions when disabled
+/** @brief No-op watchdog init when watchdog feature is disabled. */
 #define watchdog_init() (ESP_OK)
+/** @brief Always report watchdog stopped when feature is disabled. */
 #define watchdog_is_running() (false)
+/** @brief No-op watchdog feed when feature is disabled. */
 #define watchdog_update()
+/** @brief No-op watchdog delete when feature is disabled. */
 #define watchdog_delete()
+/** @brief No-op watchdog reinit when feature is disabled. */
 #define watchdog_reinit() (ESP_OK)
+/** @brief No-op mutex creation when feature is disabled. */
 #define watchdog_mutex_create()
+/** @brief No-op mutex deletion when feature is disabled. */
 #define watchdog_mutex_delete()
 
 #endif // WATCHDOG_ENABLED

--- a/ESP32/Digifiz/main/display_next.h
+++ b/ESP32/Digifiz/main/display_next.h
@@ -1,5 +1,9 @@
 #ifndef DISPLAY_NEXT_H
 #define DISPLAY_NEXT_H
+/**
+ * @file display_next.h
+ * @brief Digifiz Next LED display rendering and indicator control API.
+ */
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,92 +24,158 @@ extern "C" {
 #include "mfa.h"
 #include "fuel_pressure.h"
 
-// Turn on debug statements to the serial output
+/** @brief Enable verbose display debug logs when set to non-zero. */
 #define DEBUG  1
 
+/** @brief GPIO pin for MFA1 indicator input. */
 #define MFA1_PIN 24
+/** @brief GPIO pin for MFA2 indicator input. */
 #define MFA2_PIN 25
 
+/** @brief Analog pin used to read dashboard brightness level. */
 #define BRIGHTNESS_IN_PIN A9 //PK1
+/** @brief GPIO controlling the dashboard backlight power stage. */
 #define BACKLIGHT_CTL_PIN 26 //PA4
 
+/** @brief WS2812 data output GPIO for the Digifiz Next display chain. */
 #define WSDATA_GPIO_PIN 21
+/** @brief Number of LEDs used by the main display area. */
 #define DIGIFIZ_DISPLAY_NEXT_LEDS 271
+/** @brief Number of LEDs used by the auxiliary backlight strip. */
 #define DIGIFIZ_BACKLIGHT_LEDS 32
 
+/** @brief Compile-time flag to enable writing WS2812 display LEDs. */
 #define USE_DISPLAY_LEDS
 
+/**
+ * @brief Bit masks for 7-segment glyphs used by Digifiz number rendering.
+ */
 enum 
 {
+    /** @brief Encoded glyph for digit '0'. */
     DIGIT_NUMBER_0 = 0b0111111,
+    /** @brief Encoded glyph for digit '1'. */
     DIGIT_NUMBER_1 = 0b0011000,
+    /** @brief Encoded glyph for digit '2'. */
     DIGIT_NUMBER_2 = 0b1110110,
+    /** @brief Encoded glyph for digit '3'. */
     DIGIT_NUMBER_3 = 0b1111100,
+    /** @brief Encoded glyph for digit '4'. */
     DIGIT_NUMBER_4 = 0b1011001,
+    /** @brief Encoded glyph for digit '5'. */
     DIGIT_NUMBER_5 = 0b1101101,
+    /** @brief Encoded glyph for digit '6'. */
     DIGIT_NUMBER_6 = 0b1101111,
+    /** @brief Encoded glyph for digit '7'. */
     DIGIT_NUMBER_7 = 0b0111000,
+    /** @brief Encoded glyph for digit '8'. */
     DIGIT_NUMBER_8 = 0b1111111,
+    /** @brief Encoded glyph for digit '9'. */
     DIGIT_NUMBER_9 = 0b1111101,
+    /** @brief Empty (all segments off) glyph. */
     DIGIT_NUMBER_EMPTY = 0,
+    /** @brief Minus sign glyph. */
     DIGIT_NUMBER_MINUS = 0b1000000,
 };
 
+/**
+ * @brief Color scheme selector indexes used in @ref ColoringScheme.
+ */
 enum
 {
+    /** @brief Invalid/uninitialized scheme index. */
     COLOR_SCHEME_INVALID,
+    /** @brief Speedometer value color scheme. */
     COLOR_SCHEME_SPEEDOMETER,
+    /** @brief Clock/time digits color scheme. */
     COLOR_SCHEME_TIME,
+    /** @brief RPM numeric digits color scheme. */
     COLOR_SCHEME_RPM,
+    /** @brief RPM redline scale color scheme. */
     COLOR_SCHEME_RPM_REDLINE,
+    /** @brief Temperature value color scheme. */
     COLOR_SCHEME_TEMPERATURE,
+    /** @brief Fuel value color scheme. */
     COLOR_SCHEME_FUEL,
+    /** @brief Refuel warning color scheme. */
     COLOR_SCHEME_REFUEL,
+    /** @brief Odometer/mileage color scheme. */
     COLOR_SCHEME_MILEAGE,
+    /** @brief RPM backlight bar color scheme. */
     COLOR_SCHEME_BACKLIGHT_RPM,
+    /** @brief Main backlight color scheme. */
     COLOR_SCHEME_BACKLIGHT,
+    /** @brief Generic indicator icons color scheme. */
     COLOR_SCHEME_SIGNALS,
+    /** @brief Lights-on indicator color scheme. */
     COLOR_SCHEME_SIGNAL_LIGHTS,
+    /** @brief Front fog light indicator color scheme. */
     COLOR_SCHEME_SIGNAL_FOGLIGHTS1,
+    /** @brief Rear fog light indicator color scheme. */
     COLOR_SCHEME_SIGNAL_FOGLIGHTS2,
+    /** @brief Rear window heater indicator color scheme. */
     COLOR_SCHEME_SIGNAL_GLASSHEAT,
+    /** @brief High-beam indicator color scheme. */
     COLOR_SCHEME_SIGNAL_FARLIGHT,
+    /** @brief Left turn indicator color scheme. */
     COLOR_SCHEME_SIGNAL_LEFT_TURN_IND,
+    /** @brief Right turn indicator color scheme. */
     COLOR_SCHEME_SIGNAL_RIGHT_TURN_IND,
+    /** @brief Brake warning indicator color scheme. */
     COLOR_SCHEME_SIGNAL_BRAKES_IND,
+    /** @brief Oil pressure warning indicator color scheme. */
     COLOR_SCHEME_SIGNAL_OIL_IND,
+    /** @brief Battery warning indicator color scheme. */
     COLOR_SCHEME_SIGNAL_BATTERY_IND,
+    /** @brief MFA1 indicator color scheme. */
     COLOR_SCHEME_SIGNAL_MFA1_IND,
+    /** @brief MFA2 indicator color scheme. */
     COLOR_SCHEME_SIGNAL_MFA2_IND,
+    /** @brief Combined MFA indicator icons color scheme. */
     COLOR_SCHEME_SIGNAL_MFA_INDICATORS,
+    /** @brief MFA numeric/text area color scheme. */
     COLOR_SCHEME_MFA,
+    /** @brief Upper panel backlight color scheme. */
     COLOR_SCHEME_UPPER_BACKLIGHT,
+    /** @brief Total number of color-scheme indexes. */
     __MAX_COLOR_SCHEME
 };
 
+/** @brief Max number of keyframe segments in one configurable color scheme. */
 #define COLORING_SCHEME_MAX_ELEMENTS 50
+/** @brief RPM segment index where redline coloring begins. */
 #define COLORING_SCHEME_REDLINING_LIMIT 69
 
+/** @brief One RGB keyframe entry for a display segment range. */
 typedef struct RGBColoringElement
 {
+    /** @brief Red channel intensity (0..255). */
     uint8_t r;
+    /** @brief Green channel intensity (0..255). */
     uint8_t g;
+    /** @brief Blue channel intensity (0..255). */
     uint8_t b;
+    /** @brief Last LED segment index covered by this element. */
     int16_t end_segment;
+    /** @brief Scheme type/index this element belongs to. */
     uint8_t type;
+    /** @brief Set to non-zero to preserve base color behavior. */
     uint8_t basecolor_enabled;
 } RGBColoringElement;
 
+/** @brief Expanded per-LED color table generated from scheme keyframes. */
 typedef struct CompiledColoringScheme
 {
     RGBColoringElement scheme[DIGIFIZ_DISPLAY_NEXT_LEDS+DIGIFIZ_BACKLIGHT_LEDS];
 } CompiledColoringScheme;
 
+/** @brief Compressed color table made of keyframe segments. */
 typedef struct ColoringScheme
 {
     RGBColoringElement scheme[COLORING_SCHEME_MAX_ELEMENTS];
 } ColoringScheme;
 
+/** @brief Packed LED/segment state payload for the Digifiz Next cluster. */
 typedef struct __attribute__((packed)) DigifizNextDisplay
 {
     uint8_t coolant_backlight : 1; //1
@@ -159,46 +229,82 @@ typedef struct __attribute__((packed)) DigifizNextDisplay
     uint32_t backlight_leds:32; //282
 } DigifizNextDisplay;
 
+/** @brief Initialize display hardware and internal rendering buffers. */
 void initDisplay(); 
+/** @brief Update raw RPM bargraph payload bits. */
 void setRPM(uint32_t rpmdata);
+/** @brief Set dashboard clock digits (HH:MM). */
 void setClockData(uint8_t clock_hours,uint8_t clock_minutes);
+/** @brief Set MFA clock digits (HH:MM). */
 void setMFAClockData(uint8_t mfa_clock_hours,uint8_t mfa_clock_minutes);
+/** @brief Set currently displayed MFA numeric value. */
 void setMFADisplayedNumber(int16_t data);
+/** @brief Set displayed fuel amount (liters). */
 void setFuel(uint8_t litres);
+/** @brief Set RPM value for formatted display rendering. */
 void setRPMData(uint16_t data);
+/** @brief Set speedometer value for formatted display rendering. */
 void setSpeedometerData(uint16_t data);
+/** @brief Set currently estimated gear to display. */
 void setSpeedometerGear(int8_t gear);
+/** @brief Set displayed coolant temperature value. */
 void setCoolantData(uint16_t data);
+/** @brief Enable/disable the main decimal dot. */
 void setDot(bool value);
+/** @brief Enable/disable floating secondary dot indicator. */
 void setFloatDot(bool value);
+/** @brief Set odometer mileage value to show. */
 void setMileage(uint32_t mileage);
+/** @brief Set MFA page/type selector value. */
 void setMFAType(uint8_t mfaType);
+/** @brief Render glyph/icon matching the provided MFA type. */
 void displayMFAType(uint8_t mfaType);
+/** @brief Render MFA clock page using current MFA clock fields. */
 void displayMFAClock();
+/** @brief Select active MFA block identifier. */
 void setMFABlock(uint8_t block);
+/** @brief Apply brightness level to display and backlight LEDs. */
 void setBrightness(uint8_t levels);
+/** @brief Restore brightness to automatically calculated value. */
 void resetBrightness();
+/** @brief Toggle refuel indicator sign visibility. */
 void setRefuelSign(bool onoff);
+/** @brief Display gear hint during refuel/info mode. */
 void setRefuelGear(int8_t gear);
+/** @brief Set check-engine indicator target state. */
 void setCheckEngine(bool onoff);
+/** @brief Flush pending check-engine display action to outputs. */
 void applyCheckEngineAction(void);
+/** @brief Turn dashboard backlight LEDs on or off. */
 void setBacklight(bool onoff);
+/** @brief Set service/info display data byte. */
 void setServiceDisplayData(uint8_t data);
 
+/** @brief Build per-LED color lookup tables from configured schemes. */
 void compileColorScheme(void);
 
+/** @brief Push current framebuffer state to physical Digifiz display LEDs. */
 void fireDigifiz();
 
+/** @brief Set oil warning indicator state. */
 void setOilIndicator(bool onoff);
+/** @brief Set brakes warning indicator state. */
 void setBrakesIndicator(bool onoff);
+/** @brief Set heated-lights indicator state. */
 void setHeatLightsIndicator(bool onoff);
+/** @brief Set rear-lights heater indicator state. */
 void setBackLightsHeatIndicator(bool onoff);
+/** @brief Set rear-window heater indicator state. */
 void setBackWindowHeatIndicator(bool onoff);
+/** @brief Read indicator inputs and refresh indicator outputs. */
 void processIndicators();
 
+/** @brief Deinitialize WS2812/LED driver resources. */
 void deinit_leds(void);
 
+/** @brief User-customizable color scheme loaded from settings. */
 extern ColoringScheme digifizCustom;
+/** @brief Built-in default color scheme. */
 extern ColoringScheme digifizStandard;
 
 #ifdef __cplusplus

--- a/ESP32/Digifiz/main/ecu_data.h
+++ b/ESP32/Digifiz/main/ecu_data.h
@@ -1,16 +1,32 @@
 #ifndef ECU_DATA_H
 #define ECU_DATA_H
 
+/**
+ * @file ecu_data.h
+ * @brief Normalized ECU telemetry data container.
+ */
+
 #include <stdint.h>
 
+/**
+ * @brief Snapshot of decoded ECU telemetry values.
+ */
 typedef struct {
+    /** @brief Engine coolant temperature in degrees Celsius. */
     int8_t engine_temp_c;        // Signed degrees Celsius
+    /** @brief Throttle opening in percent (0..100). */
     uint8_t throttle_percent;    // %
+    /** @brief Engine speed in revolutions per minute. */
     uint16_t rpm;                // Revolutions per minute
+    /** @brief Idle regulator/valve position in percent. */
     uint8_t idle_regulator_pos; // Idle valve %
+    /** @brief Electrical system voltage in volts. */
     float battery_voltage;       // Volts
+    /** @brief Injector pulse duration in milliseconds. */
     float injector_duration_ms;  // ms
+    /** @brief Air mass flow in kilograms per hour. */
     float air_mass_kgph;         // kg/h
+    /** @brief Lambda probe voltage in volts. */
     float lambda_voltage;        // Volts
 } ecu_data_t;
 

--- a/ESP32/Digifiz/main/kline.h
+++ b/ESP32/Digifiz/main/kline.h
@@ -10,29 +10,54 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/** @brief UART peripheral used for K-Line communication. */
 #define KLINE_UART_NUM      UART_NUM_1
+/** @brief GPIO pin used as K-Line TX output. */
 #define KLINE_TX_PIN        43
+/** @brief GPIO pin used as K-Line RX input. */
 #define KLINE_RX_PIN        44
+/** @brief K-Line bus baud rate (ISO 9141 typical). */
 #define KLINE_BAUD_RATE     10400
+/** @brief Maximum received K-Line message payload length. */
 #define KLINE_BUFFER_SIZE   128
 
+/**
+ * @brief K-Line protocol connection and polling state.
+ */
 typedef enum {
+    /** @brief Link is not initialized or disconnected. */
     KLINE_MODE_DISCONNECTED = 0,
+    /** @brief Connection handshake is in progress. */
     KLINE_MODE_CONNECTING,
+    /** @brief Reading standard data frame sequence. */
     KLINE_MODE_READDATA,
+    /** @brief Reading ECU error frame sequence. */
     KLINE_MODE_READERROR,
+    /** @brief Reading speed sample frame sequence. */
     KLINE_MODE_SPEEDSAMPLE
 } kline_mode_t;
 
+/**
+ * @brief Raw K-Line frame container.
+ */
 typedef struct {
+    /** @brief Byte buffer with K-Line message payload. */
     uint8_t data[KLINE_BUFFER_SIZE];
+    /** @brief Number of valid bytes stored in @ref data. */
     uint16_t len;
 } kline_message_t;
 
+/**
+ * @brief Runtime K-Line protocol state.
+ */
 typedef struct {
+    /** @brief Current K-Line state machine mode. */
     kline_mode_t mode;
+    /** @brief Indicates transmitter may send a new frame. */
     bool ready_to_send;
+    /** @brief Timestamp of the last transmitted frame (ms). */
     uint32_t last_send_time_ms;
+    /** @brief Last received message buffer and length. */
     kline_message_t rx_msg;
 } kline_state_t;
 

--- a/ESP32/Digifiz/main/led_effects.h
+++ b/ESP32/Digifiz/main/led_effects.h
@@ -9,41 +9,79 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/**
+ * @brief RGB color triplet.
+ */
 typedef struct {
+    /** @brief Red channel intensity (0..255). */
     uint8_t r;
+    /** @brief Green channel intensity (0..255). */
     uint8_t g;
+    /** @brief Blue channel intensity (0..255). */
     uint8_t b;
 } led_rgb_t;
 
+/**
+ * @brief HSV color triplet.
+ */
 typedef struct {
+    /** @brief Hue component (0..255). */
     uint8_t h;
+    /** @brief Saturation component (0..255). */
     uint8_t s;
+    /** @brief Value/brightness component (0..255). */
     uint8_t v;
 } led_hsv_t;
 
+/**
+ * @brief Available procedural LED effects.
+ */
 typedef enum {
+    /** @brief Static color output. */
     LED_EFFECT_NONE = 0,
+    /** @brief Cyclic hue/gradient animation. */
     LED_EFFECT_CYCLE,
+    /** @brief Flame-like procedural animation. */
     LED_EFFECT_FIRE,
+    /** @brief Magic sparkle/fantasy animation preset. */
     LED_EFFECT_MAGIC,
+    /** @brief Plasma field animation. */
     LED_EFFECT_PLASMA,
+    /** @brief Cloud-style smooth evolving pattern. */
     LED_EFFECT_CLOUDS,
+    /** @brief Slowly fading trail effect. */
     LED_EFFECT_AFTERGLOW,
+    /** @brief Dynamic hue-shift effect. */
     LED_EFFECT_COLOR_SHIFT,
+    /** @brief Segment-based fire animation. */
     LED_EFFECT_SEGMENT_FIRE,
+    /** @brief Rainbow sweep pattern. */
     LED_EFFECT_RAINBOW,
+    /** @brief Random glitter particles. */
     LED_EFFECT_GLITTER,
+    /** @brief Traveling wave pattern. */
     LED_EFFECT_WAVE,
+    /** @brief Breathing brightness effect. */
     LED_EFFECT_BREATHING,
+    /** @brief Confetti particle bursts. */
     LED_EFFECT_CONFETTI,
+    /** @brief Number of supported effect types. */
     LED_EFFECT_MAX
 } led_effect_t;
 
+/**
+ * @brief Mutable state used by LED effect renderer.
+ */
 typedef struct {
+    /** @brief Currently selected effect type. */
     led_effect_t effect;
+    /** @brief Base hue used by effect algorithms. */
     uint8_t hue;
+    /** @brief Base saturation used by effect algorithms. */
     uint8_t saturation;
+    /** @brief Base value/brightness used by effect algorithms. */
     uint8_t value;
+    /** @brief Animation phase accumulator. */
     float phase;
 } led_effect_state_t;
 

--- a/ESP32/Digifiz/main/tacho.h
+++ b/ESP32/Digifiz/main/tacho.h
@@ -1,5 +1,10 @@
 #ifndef TACHO_H
 #define TACHO_H
+/**
+ * @file tacho.h
+ * @brief Engine RPM pulse capture and filtering interface.
+ */
+
 #include <stdint.h>
 #include <math.h>
 #include "esp_log.h"
@@ -13,13 +18,22 @@
 #include "freertos/task.h"
 #include "freertos/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief GPIO connected to the tachometer pulse source. */
 #define RPM_PIN 35
+/** @brief Debounce threshold in timer ticks for pulse qualification. */
 #define DEBOUNCE_TICKS 50 //0.5ms
+/** @brief Moving window size used by RPM filter internals. */
 #define RPM_WINDOW_SIZE 8  // Adjust as needed for your application
 
-// Circular buffer to hold the most recent data points
+/** @brief Circular buffer for recent RPM samples. */
 typedef struct {
+    /** @brief Sample storage array (latest values in ring order). */
     uint32_t data[RPM_WINDOW_SIZE];
+    /** @brief Write index in @ref data ring buffer. */
     uint8_t index;
 } CircularBuffer;
 
@@ -59,4 +73,8 @@ void deinit_gptimer(void);
  * @brief resets gpio periph
  */
 void deinit_tacho_gpio(void);
+
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
### Motivation
- Improve generated API documentation by adding Doxygen comments for previously undocumented enums, `#define` macros, structs, and public functions in the ESP32 codebase headers.
- Make intent and field-level semantics explicit so maintainers and documentation consumers can understand interfaces and configuration constants without reading implementation code.

### Description
- Added file-level and API Doxygen comments to `display_next.h` documenting macros, 7-segment glyph enums, color-scheme enums, color element structs, the packed display payload, extern color-scheme objects, and all public functions.
- Documented K-Line transport constants, `kline_mode_t`, `kline_message_t`, and `kline_state_t` in `kline.h` and preserved existing API comments for the public functions.
- Annotated `led_effects.h` types and `led_effect_t` enum entries and documented the effect state and effect APIs.
- Added file and API documentation plus clarified no-op fallback macros to `digifiz_watchdog.h` so the enabled/disabled behavior is clear.
- Documented ECU telemetry fields in `ecu_data.h` with per-field descriptions.
- Improved `tacho.h` with file-level docs, define/struct field docs, and added explicit `extern "C"` guards around declarations for C++ compatibility.
- Enhanced `components/xparam/xparam.h` with Doxygen for the `xparam_vtype_t` enum, helper macros, serialization size macro, and all public function declarations.

### Testing
- Ran `git diff --check` to validate whitespace and formatting issues; the check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de33f02300832396e22c11adb11239)