### PR TITLE
Add packed payload command and store Refiz pattern as packed bytes

### DIFF
--- a/ESP32/Digifiz/main/display_refiz.c
+++ b/ESP32/Digifiz/main/display_refiz.c
@@ -73,89 +73,30 @@ static bool check_engine_speed_override_active = false;
 static uint8_t d_clock_hours = 0;
 static uint8_t d_clock_minutes = 0;
 
-#define PAYLOAD_SIZE 520 
+#define PAYLOAD_SIZE 520
+#define PACKED_PAYLOAD_SIZE ((PAYLOAD_SIZE + 7) / 8)
 #define SEND_PAYLOAD_SIZE 260 //We do not transmit extra data
 #define REFIZ_UART_BAUD 250000
 #define REFIZ_UART_NUM UART_NUM_1
 #define REFIZ_UART_TX_PIN 43
 #define REFIZ_UART_RX_PIN UART_PIN_NO_CHANGE
 #define REFIZ_UART_BATCH_OFFSET_START 3
-#define REFIZ_UART_BATCH_SIZE 8
+#define REFIZ_UART_BATCH_SIZE 64
 #define REFIZ_UART_SET_RANGE_CMD 0x02
+#define REFIZ_UART_SET_PACKED_RANGE_CMD 0x03
 #define REFIZ_UART_SOF1 0xA5
 #define REFIZ_UART_SOF2 0x5A
 #define REFIZ_UART_TX_BUFFER_SIZE 1024
 
-static const uint8_t refiz_default_payload[PAYLOAD_SIZE] = {
-1,1,1,
-0, 0, 0, 0, 0, 0, 0, 0, //first, second digit clock top 
-0, 0, 0, 0, 0, 0, 0, 0, //third, fourth digit clock top 
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (1700-1900) + MFA
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (1000-1700) 
-0, 0, 0, 0, 0, 0, 0, 0, //first and second digit clock bot
-0, 0, 0, 0, 0, 0, 0, 0, //third and fourth digit clock bot
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (5100-5200) + MFA
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (6000-5300)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (0-700)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho(800-900)) + mileage(1-2)
-0, 0, 0, 0, 0, 0, 0, 0, //mileage(3-4)
-0, 0, 0, 0, 0, 0, 0, 0, //mileage(5-6)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (7000-6300)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho (6200-6100) + mileage(1-2)
-0, 0, 0, 0, 0, 0, 0, 0, //mileage (3-4)  
-0, 0, 0, 0, 0, 0, 0, 0, //mileage (5-6)
-0, 0, 0, 0, 0, 0, 0, 0, //fuel second digit, coolant T (9-10)
-0, 0, 0, 0, 0, 0, 0, 0, //coolant T(1-8)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho(3400-2800)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho(2700-2000)
-0, 0, 0, 0, 0, 0, 0, 0, //fuel down, coolant T(11-12)
-0, 0, 0, 0, 0, 0, 0, 0, //coolant T(13-20)
-0, 0, 0, 0, 0, 0, 0, 0, //refuel sign, tacho(3600-4200)
-0, 0, 0, 0, 0, 0, 0, 0, //tacho(4300-5000)
-0, 0, 0, 0, 0, 0, 0, 0, //mfa (1,2 digit top)
-0, 0, 0, 0, 0, 0, 0, 0, //mfa (dot, 3,4)
-0, 0, 0, 0, 0, 0, 0, 0, //mfa (4), speed (3)
-0, 0, 0, 0, 0, 0, 0, 0, //speed(1-2), fuel(1 top)
-0, 0, 0, 0, 0, 0, 0, 0, //mfa bottom 1,2
-0, 0, 0, 0, 0, 0, 0, 0, //mfa float dot, mfa bot 3,4
-0, 0, 0, 0, 0, 0, 0, 0, //mfa bot 4, speed top 3
-0, 0, 0, 0, 0, 0, 0, 0, //speed 2-1 top, tacho, fuel shit and etc
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0,
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-1, 1, 1, 1, 1, 1, 1, 0, 
-1, 1, 1, 0, 0, 0, 1, 1, 
-1, 1, 1, 1, 1, 0, 1, 1, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-1, 1, 1, 1, 1, 1, 1, 0, 
-1, 1, 1, 1, 1, 1, 1, 1, 
-1, 0, 1, 1, 1, 1, 0, 1, 
-1, 1, 1, 1, 1, 0, 1, 1, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-0, 0, 0, 0, 0, 0, 0, 0, 
-1,1,1,1,1
+static const uint8_t refiz_default_payload[PACKED_PAYLOAD_SIZE] = {
+  0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x3B,
+  0xFE, 0x06, 0x00, 0x00, 0x00, 0xF8, 0xFB, 0xEF, 0xFD, 0x06, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8
 };
 
-static uint8_t bool_data_payload[PAYLOAD_SIZE];
+static uint8_t bool_data_payload[PACKED_PAYLOAD_SIZE];
 static uint16_t refiz_uart_next_offset = REFIZ_UART_BATCH_OFFSET_START;
 static bool refiz_uart_ready = false;
 
@@ -173,6 +114,32 @@ static const uint16_t refiz_rpm_segments[71] = {
     56, 105, 104, 103, 102, 101, 100, 99, 98, 97,
     96
 };
+
+static uint8_t refiz_payload_get_bit(uint16_t bit_index)
+{
+    if (bit_index >= PAYLOAD_SIZE)
+    {
+        return 0;
+    }
+    return (bool_data_payload[bit_index >> 3] & (1 << (bit_index & 0x07))) ? 1 : 0;
+}
+
+static void refiz_payload_set_bit(uint16_t bit_index, uint8_t value)
+{
+    if (bit_index >= PAYLOAD_SIZE)
+    {
+        return;
+    }
+    const uint8_t mask = 1 << (bit_index & 0x07);
+    if (value)
+    {
+        bool_data_payload[bit_index >> 3] |= mask;
+    }
+    else
+    {
+        bool_data_payload[bit_index >> 3] &= ~mask;
+    }
+}
 
 static uint8_t refiz_next_digit_to_orig(uint8_t next_pattern)
 {
@@ -204,7 +171,7 @@ static void refiz_put_digit(const uint16_t segments[7], uint8_t next_pattern)
     uint8_t orig_pattern = refiz_next_digit_to_orig(next_pattern);
     for (uint8_t i = 0; i < 7; i++)
     {
-        bool_data_payload[segments[i] + 3] = (orig_pattern & (1 << i)) ? 1 : 0;
+        refiz_payload_set_bit(segments[i] + 3, (orig_pattern & (1 << i)) ? 1 : 0);
     }
 }
 
@@ -257,25 +224,25 @@ static void refiz_sync_payload_from_display(void)
     refiz_put_digit(clock_segments[1], display.clock_digit_2);
     refiz_put_digit(clock_segments[2], display.clock_digit_3);
     refiz_put_digit(clock_segments[3], display.clock_digit_4);
-    bool_data_payload[40 + 3] = (display.clock_dot != 0) ? 1 : 0;
+    refiz_payload_set_bit(40 + 3, (display.clock_dot != 0) ? 1 : 0);
 
-    bool_data_payload[51 + 3] = (display.mfa_indicators & 0x01) ? 1 : 0;
-    bool_data_payload[19 + 3] = (display.mfa_indicators & 0x02) ? 1 : 0;
-    bool_data_payload[52 + 3] = (display.mfa_indicators & 0x04) ? 1 : 0;
-    bool_data_payload[20 + 3] = (display.mfa_indicators & 0x10) ? 1 : 0;
-    bool_data_payload[21 + 3] = (display.mfa_indicators & 0x20) ? 1 : 0;
-    bool_data_payload[53 + 3] = (display.mfa_indicators & 0x40) ? 1 : 0;
+    refiz_payload_set_bit(51 + 3, (display.mfa_indicators & 0x01) ? 1 : 0);
+    refiz_payload_set_bit(19 + 3, (display.mfa_indicators & 0x02) ? 1 : 0);
+    refiz_payload_set_bit(52 + 3, (display.mfa_indicators & 0x04) ? 1 : 0);
+    refiz_payload_set_bit(20 + 3, (display.mfa_indicators & 0x10) ? 1 : 0);
+    refiz_payload_set_bit(21 + 3, (display.mfa_indicators & 0x20) ? 1 : 0);
+    refiz_payload_set_bit(53 + 3, (display.mfa_indicators & 0x40) ? 1 : 0);
 
     refiz_put_digit(mfa_segments[0], display.mfa_digit_1);
     refiz_put_digit(mfa_segments[1], display.mfa_digit_2);
     refiz_put_digit(mfa_segments[2], display.mfa_digit_3);
     refiz_put_digit(mfa_segments[3], display.mfa_digit_4);
-    bool_data_payload[200 + 3] = (display.mfa_dots & 0x01) ? 1 : 0;
-    bool_data_payload[232 + 3] = (display.mfa_dots & 0x04) ? 1 : 0;
+    refiz_payload_set_bit(200 + 3, (display.mfa_dots & 0x01) ? 1 : 0);
+    refiz_payload_set_bit(232 + 3, (display.mfa_dots & 0x04) ? 1 : 0);
 
     refiz_put_digit(fuel_segments[0], display.fuel_digit_1);
     refiz_put_digit(fuel_segments[1], display.fuel_digit_2);
-    bool_data_payload[176 + 3] = display.fuel_low_ind ? 1 : 0;
+    refiz_payload_set_bit(176 + 3, display.fuel_low_ind ? 1 : 0);
 
     refiz_put_digit(speed_segments[0], display.speed_digit_1);
     refiz_put_digit(speed_segments[1], display.speed_digit_2);
@@ -284,7 +251,7 @@ static void refiz_sync_payload_from_display(void)
     uint16_t coolant_value = display.coolant_value;
     for (uint8_t i = 0; i < 20; i++)
     {
-        bool_data_payload[coolant_segments[i] + 3] = (coolant_value & (1 << i)) ? 1 : 0;
+        refiz_payload_set_bit(coolant_segments[i] + 3, (coolant_value & (1 << i)) ? 1 : 0);
     }
 
     const uint8_t *display_bits = (const uint8_t *)&display;
@@ -298,9 +265,9 @@ static void refiz_sync_payload_from_display(void)
     }
     for (uint8_t i = 0; i < 71; i++)
     {
-        bool_data_payload[refiz_rpm_segments[i] + 3] = (i < rpm_segments_on) ? 1 : 0;
+        refiz_payload_set_bit(refiz_rpm_segments[i] + 3, (i < rpm_segments_on) ? 1 : 0);
     }
-    bool_data_payload[refiz_rpm_segments[0] + 3] = 1;
+    refiz_payload_set_bit(refiz_rpm_segments[0] + 3, 1);
 }
 
 void refiz_uart_sender_init(void)
@@ -337,7 +304,7 @@ void refiz_uart_sender_trigger(void)
         return;
     }
 
-    //refiz_sync_payload_from_display();
+    refiz_sync_payload_from_display();
 
     uint16_t offset = refiz_uart_next_offset;
     if (offset >= SEND_PAYLOAD_SIZE)
@@ -351,20 +318,28 @@ void refiz_uart_sender_trigger(void)
         count = SEND_PAYLOAD_SIZE - offset;
     }
 
-    uint8_t frame[2 + 3 + 4 + REFIZ_UART_BATCH_SIZE + 1];
-    const uint16_t payload_len = 4 + count;
+    uint8_t frame[2 + 3 + 4 + ((REFIZ_UART_BATCH_SIZE + 7) / 8) + 1];
+    const uint16_t byte_count = (count + 7) / 8;
+    const uint16_t payload_len = 4 + byte_count;
     size_t pos = 0;
     frame[pos++] = REFIZ_UART_SOF1;
     frame[pos++] = REFIZ_UART_SOF2;
-    frame[pos++] = REFIZ_UART_SET_RANGE_CMD;
+    frame[pos++] = REFIZ_UART_SET_PACKED_RANGE_CMD;
     frame[pos++] = payload_len & 0xFF;
     frame[pos++] = (payload_len >> 8) & 0xFF;
     frame[pos++] = offset & 0xFF;
     frame[pos++] = (offset >> 8) & 0xFF;
     frame[pos++] = count & 0xFF;
     frame[pos++] = (count >> 8) & 0xFF;
-    memcpy(&frame[pos], &bool_data_payload[offset], count);
-    pos += count;
+    memset(&frame[pos], 0, byte_count);
+    for (uint16_t i = 0; i < count; i++)
+    {
+        if (refiz_payload_get_bit(offset + i))
+        {
+            frame[pos + (i >> 3)] |= 1 << (i & 0x07);
+        }
+    }
+    pos += byte_count;
 
     uint8_t crc = 0;
     for (size_t i = 2; i < pos; i++)

--- a/SLCD_DR_Ctl/PROTOCOL.md
+++ b/SLCD_DR_Ctl/PROTOCOL.md
@@ -1,7 +1,7 @@
 # SLCD_DR_Ctl UART protocol
 
 UART settings:
-- Baud: **115200**
+- Baud: **250000**
 - Data bits: 8
 - Parity: none
 - Stop bits: 1
@@ -44,6 +44,19 @@ OFF_L OFF_H CNT_L CNT_H DATA0 DATA1 ... DATA(CNT-1)
 - `count` = `CNT_L | CNT_H<<8`
 - total payload size must be exactly `4 + count`
 
+### `0x03` SET_PACKED_RANGE
+Update all or part of the payload with packed bits. This preserves the `0x01` and `0x02` commands while reducing transfer size by up to 8x.
+
+Payload:
+```text
+OFF_L OFF_H BIT_CNT_L BIT_CNT_H PACKED0 PACKED1 ... PACKED(ceil(BIT_CNT/8)-1)
+```
+- `offset` = `OFF_L | OFF_H<<8`, expressed in payload bits.
+- `bit_count` = `BIT_CNT_L | BIT_CNT_H<<8`.
+- total payload size must be exactly `4 + ceil(bit_count / 8)`.
+- bit order is little-endian inside each packed byte: the first payload bit is bit 0 of `PACKED0`, the second is bit 1, and so on.
+- use `offset = 0` and `bit_count = 520` to set the whole pattern.
+
 ### `0x10` GET_INFO
 No payload.
 
@@ -66,6 +79,8 @@ Error codes:
 - `0x02` invalid SET_RANGE length mismatch
 - `0x03` invalid GET_RANGE request length
 - `0x04` requested range count too large
+- `0x07` invalid SET_PACKED_RANGE payload (too short)
+- `0x08` invalid SET_PACKED_RANGE length mismatch
 - `0x05` payload too large for parser
 - `0x06` CRC mismatch
 - `0x7F` unknown command
@@ -84,6 +99,6 @@ Payload: bytes with requested payload content.
 
 1. Send `GET_INFO` to get payload size.
 2. Build byte payload in host app (`0`/`1` bytes).
-3. Send `SET_ALL` to replace full frame, or `SET_RANGE` for partial updates.
+3. Prefer `SET_PACKED_RANGE` (`0x03`) to set the full frame or partial ranges with packed bytes. Legacy `SET_ALL` and `SET_RANGE` remain available for unpacked `0`/`1` byte payloads.
 4. Wait for `ACK`.
 

--- a/SLCD_DR_Ctl/config.h
+++ b/SLCD_DR_Ctl/config.h
@@ -16,4 +16,5 @@ constexpr uint8_t DATA_PIN_NAME = PB2;
 #define DATA_PORT PORTB
 
 constexpr uint16_t PAYLOAD_SIZE = 520;
+constexpr uint16_t PACKED_PAYLOAD_SIZE = (PAYLOAD_SIZE + 7) / 8;
 constexpr uint32_t UART_BAUD = 250000;

--- a/SLCD_DR_Ctl/pattern_sender.cpp
+++ b/SLCD_DR_Ctl/pattern_sender.cpp
@@ -1,75 +1,35 @@
 #include "pattern_sender.h"
 
+#include <string.h>
+
 volatile uint8_t tr_status = 0x00; // sending, clockbit, 000000
 volatile uint16_t data_cnt = 0;
-volatile uint8_t bool_data_payload[PAYLOAD_SIZE] = {
-  1,1,1,
-  0, 1, 0, 0, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 0,
-  0, 1, 1, 1, 1, 1, 0, 0,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  0, 1, 1, 0, 0, 1, 0, 1,
-  0, 1, 1, 1, 1, 0, 1, 1,
-  1, 1, 1, 0, 1, 0, 0, 0,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 0, 0, 0, 0, 0, 0,
-  1, 1, 1, 1, 0, 1, 1, 1,
-  1, 1, 0, 1, 0, 1, 0, 0,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 0, 0, 0, 0, 0, 0,
-  1, 1, 0, 0, 0, 1, 0, 1,
-  0, 1, 1, 1, 0, 1, 1, 0,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  0, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  0, 1, 1, 1, 1, 1, 1, 1,
-  1, 0, 0, 0, 1, 1, 1, 1,
-  1, 0, 0, 0, 1, 0, 1, 1,
-  1, 0, 1, 1, 0, 1, 0, 0,
-  0, 1, 1, 1, 0, 1, 1, 1,
-  1, 0, 1, 1, 1, 0, 1, 1,
-  1, 0, 0, 0, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 0, 1,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  1, 1, 1, 1, 1, 1, 1, 0,
-  1, 1, 1, 0, 0, 0, 1, 1,
-  1, 1, 1, 1, 1, 0, 1, 1,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  1, 1, 1, 1, 1, 1, 1, 0,
-  1, 1, 1, 1, 1, 1, 1, 1,
-  1, 0, 1, 1, 1, 1, 0, 1,
-  1, 1, 1, 1, 1, 0, 1, 1,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0,
-  1,1,1,1,1
+volatile uint8_t bool_data_payload[PACKED_PAYLOAD_SIZE] = {
+  0x97, 0xFF, 0xF3, 0xF9, 0x37, 0xF5, 0xBE, 0xF8, 0xFF, 0x1F, 0x78, 0x5F, 0xF9,
+  0x1F, 0x18, 0x75, 0xFB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF7, 0xFF, 0xF7, 0x8F,
+  0x8F, 0x6E, 0x71, 0xEF, 0x8E, 0xFF, 0x05, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x3B,
+  0xFE, 0x06, 0x00, 0x00, 0x00, 0xF8, 0xFB, 0xEF, 0xFD, 0x06, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8
 };
+
+static bool getPayloadBit(uint16_t bit_index) {
+  if (bit_index >= PAYLOAD_SIZE) {
+    return false;
+  }
+  return (bool_data_payload[bit_index >> 3] & (1 << (bit_index & 0x07))) != 0;
+}
+
+static void setPayloadBit(uint16_t bit_index, bool value) {
+  if (bit_index >= PAYLOAD_SIZE) {
+    return;
+  }
+  const uint8_t mask = 1 << (bit_index & 0x07);
+  if (value) {
+    bool_data_payload[bit_index >> 3] |= mask;
+  } else {
+    bool_data_payload[bit_index >> 3] &= ~mask;
+  }
+}
 
 void initDisplayClockTimer() {
   cli();
@@ -129,14 +89,14 @@ ISR(TIMER1_COMPA_vect) {
 
       if (data_cnt > 250) {
         delayMicroseconds(8);
-        if (bool_data_payload[data_cnt]) {
+        if (getPayloadBit(data_cnt)) {
           DATA_PORT |= (1 << DATA_PIN_NAME);
         } else {
           DATA_PORT &= ~(1 << DATA_PIN_NAME);
         }
       } else if (data_cnt > 3) {
         delayMicroseconds(8);
-        if (bool_data_payload[data_cnt]) {
+        if (getPayloadBit(data_cnt)) {
           DATA_PORT |= (1 << DATA_PIN_NAME);
         } else {
           DATA_PORT &= ~(1 << DATA_PIN_NAME);
@@ -178,8 +138,9 @@ void setPayloadAll(const uint8_t* src, uint16_t len) {
     len = PAYLOAD_SIZE;
   }
   noInterrupts();
-  for (uint16_t i = 0; i < PAYLOAD_SIZE; ++i) {
-    bool_data_payload[i] = (i < len && src[i] != 0) ? 1 : 0;
+  memset((void*)bool_data_payload, 0, PACKED_PAYLOAD_SIZE);
+  for (uint16_t i = 0; i < len; ++i) {
+    setPayloadBit(i, src[i] != 0);
   }
   interrupts();
 }
@@ -193,7 +154,22 @@ void setPayloadRange(uint16_t offset, const uint8_t* src, uint16_t len) {
   }
   noInterrupts();
   for (uint16_t i = 0; i < len; ++i) {
-    bool_data_payload[offset + i] = (src[i] != 0) ? 1 : 0;
+    setPayloadBit(offset + i, src[i] != 0);
+  }
+  interrupts();
+}
+
+void setPayloadPackedRange(uint16_t offset, const uint8_t* src, uint16_t bit_len) {
+  if (offset >= PAYLOAD_SIZE || bit_len == 0) {
+    return;
+  }
+  if (offset + bit_len > PAYLOAD_SIZE) {
+    bit_len = PAYLOAD_SIZE - offset;
+  }
+  noInterrupts();
+  for (uint16_t i = 0; i < bit_len; ++i) {
+    const bool value = (src[i >> 3] & (1 << (i & 0x07))) != 0;
+    setPayloadBit(offset + i, value);
   }
   interrupts();
 }
@@ -211,7 +187,7 @@ void getPayloadRange(uint16_t offset, uint8_t* dst, uint16_t len) {
   }
   noInterrupts();
   for (uint16_t i = 0; i < len; ++i) {
-    dst[i] = bool_data_payload[offset + i];
+    dst[i] = getPayloadBit(offset + i) ? 1 : 0;
   }
   interrupts();
 }

--- a/SLCD_DR_Ctl/pattern_sender.h
+++ b/SLCD_DR_Ctl/pattern_sender.h
@@ -5,7 +5,7 @@
 
 extern volatile uint8_t tr_status;
 extern volatile uint16_t data_cnt;
-extern volatile uint8_t bool_data_payload[PAYLOAD_SIZE];
+extern volatile uint8_t bool_data_payload[PACKED_PAYLOAD_SIZE];
 
 void initDisplayClockTimer();
 void initDigifiz();
@@ -14,5 +14,6 @@ void triggerFrameIfIdle();
 
 void setPayloadAll(const uint8_t* src, uint16_t len);
 void setPayloadRange(uint16_t offset, const uint8_t* src, uint16_t len);
+void setPayloadPackedRange(uint16_t offset, const uint8_t* src, uint16_t bit_len);
 uint16_t getPayloadSize();
 void getPayloadRange(uint16_t offset, uint8_t* dst, uint16_t len);

--- a/SLCD_DR_Ctl/payload_sender_pyqt5.py
+++ b/SLCD_DR_Ctl/payload_sender_pyqt5.py
@@ -12,6 +12,7 @@ SOF2 = 0x5A
 
 CMD_SET_ALL = 0x01
 CMD_SET_RANGE = 0x02
+CMD_SET_PACKED_RANGE = 0x03
 CMD_GET_INFO = 0x10
 CMD_GET_RANGE = 0x11
 
@@ -21,6 +22,7 @@ RSP_INFO = 0x90
 RSP_RANGE = 0x91
 
 BAUD = 250000
+DEFAULT_PAYLOAD_BITS = 520
 
 
 def crc8(data: bytes) -> int:
@@ -36,6 +38,24 @@ def pack_frame(cmd: int, payload: bytes = b"") -> bytes:
     return bytes([SOF1, SOF2]) + header + payload + bytes([c])
 
 
+def pack_bits(bits: bytes) -> bytes:
+    packed = bytearray((len(bits) + 7) // 8)
+    for i, bit in enumerate(bits):
+        if bit:
+            packed[i >> 3] |= 1 << (i & 0x07)
+    return bytes(packed)
+
+
+def make_packed_range_payload(offset: int, bits: bytes) -> bytes:
+    count = len(bits)
+    return bytes([
+        offset & 0xFF,
+        (offset >> 8) & 0xFF,
+        count & 0xFF,
+        (count >> 8) & 0xFF,
+    ]) + pack_bits(bits)
+
+
 @dataclass
 class Frame:
     cmd: int
@@ -46,7 +66,7 @@ class SerialClient:
     def __init__(self):
         self.ser = None
 
-    def connect(self, port: str, baud: int = BAUD  ):
+    def connect(self, port: str, baud: int = BAUD):
         self.ser = serial.Serial(port, baudrate=baud, timeout=0.7)
 
     def close(self):
@@ -123,10 +143,12 @@ class MainWindow(QtWidgets.QWidget):
 
         self.send_all_btn = QtWidgets.QPushButton("Send SET_ALL")
         self.send_range_btn = QtWidgets.QPushButton("Send SET_RANGE")
+        self.send_packed_all_btn = QtWidgets.QPushButton("Send PACKED_ALL")
+        self.send_packed_range_btn = QtWidgets.QPushButton("Send PACKED_RANGE")
         self.info_btn = QtWidgets.QPushButton("GET_INFO")
         self.get_range_btn = QtWidgets.QPushButton("GET_RANGE")
 
-        self.random_range_btn = QtWidgets.QPushButton("Randomize SET_RANGE: OFF")
+        self.random_range_btn = QtWidgets.QPushButton("Randomize PACKED_RANGE: OFF")
         self.random_range_btn.setCheckable(True)
 
         self.random_timer = QtCore.QTimer(self)
@@ -152,6 +174,8 @@ class MainWindow(QtWidgets.QWidget):
         btn_row = QtWidgets.QHBoxLayout()
         btn_row.addWidget(self.send_all_btn)
         btn_row.addWidget(self.send_range_btn)
+        btn_row.addWidget(self.send_packed_all_btn)
+        btn_row.addWidget(self.send_packed_range_btn)
         btn_row.addWidget(self.info_btn)
         btn_row.addWidget(self.get_range_btn)
         btn_row.addWidget(self.random_range_btn)
@@ -169,6 +193,8 @@ class MainWindow(QtWidgets.QWidget):
         self.connect_btn.clicked.connect(self.toggle_connect)
         self.send_all_btn.clicked.connect(self.send_all)
         self.send_range_btn.clicked.connect(self.send_range)
+        self.send_packed_all_btn.clicked.connect(self.send_packed_all)
+        self.send_packed_range_btn.clicked.connect(self.send_packed_range)
         self.info_btn.clicked.connect(self.get_info)
         self.get_range_btn.clicked.connect(self.get_range)
         self.random_range_btn.toggled.connect(self.toggle_random_range)
@@ -257,6 +283,41 @@ class MainWindow(QtWidgets.QWidget):
         except Exception as e:
             self.log_msg(f"SET_RANGE error: {e}")
 
+    def send_packed_all(self):
+        try:
+            data = self.parse_payload_text()
+            padded = data[:DEFAULT_PAYLOAD_BITS].ljust(DEFAULT_PAYLOAD_BITS, b"\x00")
+            payload = make_packed_range_payload(0, padded)
+            fr = self.transact(CMD_SET_PACKED_RANGE, payload)
+
+            if fr.cmd == RSP_ACK:
+                self.log_msg(
+                    f"PACKED_ALL ACK bits={len(padded)}, payload_bytes={len(payload)}"
+                )
+            else:
+                self.log_msg(f"Unexpected response: 0x{fr.cmd:02X}")
+
+        except Exception as e:
+            self.log_msg(f"PACKED_ALL error: {e}")
+
+    def send_packed_range(self):
+        try:
+            data = self.parse_payload_text()
+            offset = self.offset_spin.value()
+            payload = make_packed_range_payload(offset, data)
+            fr = self.transact(CMD_SET_PACKED_RANGE, payload)
+
+            if fr.cmd == RSP_ACK:
+                self.log_msg(
+                    "PACKED_RANGE ACK "
+                    f"offset={offset}, bits={len(data)}, payload_bytes={len(payload)}"
+                )
+            else:
+                self.log_msg(f"Unexpected response: 0x{fr.cmd:02X}")
+
+        except Exception as e:
+            self.log_msg(f"PACKED_RANGE error: {e}")
+
     def get_info(self):
         try:
             fr = self.transact(CMD_GET_INFO)
@@ -303,13 +364,13 @@ class MainWindow(QtWidgets.QWidget):
                 self.random_range_btn.setChecked(False)
                 return
 
-            self.random_range_btn.setText("Randomize SET_RANGE: ON")
+            self.random_range_btn.setText("Randomize PACKED_RANGE: ON")
             self.random_timer.start()
-            self.log_msg("Randomize SET_RANGE started @ 32 Hz")
+            self.log_msg("Randomize PACKED_RANGE started @ 32 Hz")
         else:
             self.random_timer.stop()
-            self.random_range_btn.setText("Randomize SET_RANGE: OFF")
-            self.log_msg("Randomize SET_RANGE stopped")
+            self.random_range_btn.setText("Randomize PACKED_RANGE: OFF")
+            self.log_msg("Randomize PACKED_RANGE stopped")
 
     def randomize_send_range(self):
         try:
@@ -321,26 +382,24 @@ class MainWindow(QtWidgets.QWidget):
 
             data = bytes(random.getrandbits(1) for _ in range(count))
 
-            payload = bytes([
-                offset & 0xFF,
-                (offset >> 8) & 0xFF,
-                count & 0xFF,
-                (count >> 8) & 0xFF,
-            ]) + data
+            payload = make_packed_range_payload(offset, data)
 
-            self.client.send(CMD_SET_RANGE, payload)
+            self.client.send(CMD_SET_PACKED_RANGE, payload)
 
             fr = self.client.read_frame()
 
             if fr.cmd == RSP_ACK:
-                self.log_msg(f"Random SET_RANGE ACK offset={offset}, count={count}")
+                self.log_msg(
+                    "Random PACKED_RANGE ACK "
+                    f"offset={offset}, count={count}, payload_bytes={len(payload)}"
+                )
             elif fr.cmd == RSP_NACK:
-                self.log_msg("Random SET_RANGE NACK")
+                self.log_msg("Random PACKED_RANGE NACK")
             else:
-                self.log_msg(f"Random SET_RANGE unexpected response: 0x{fr.cmd:02X}")
+                self.log_msg(f"Random PACKED_RANGE unexpected response: 0x{fr.cmd:02X}")
 
         except Exception as e:
-            self.log_msg(f"Random SET_RANGE error: {e}")
+            self.log_msg(f"Random PACKED_RANGE error: {e}")
             self.random_range_btn.setChecked(False)
 
     def closeEvent(self, event):

--- a/SLCD_DR_Ctl/serial_protocol.cpp
+++ b/SLCD_DR_Ctl/serial_protocol.cpp
@@ -7,6 +7,7 @@ constexpr uint8_t SOF1 = 0xA5;
 constexpr uint8_t SOF2 = 0x5A;
 constexpr uint8_t CMD_SET_ALL = 0x01;
 constexpr uint8_t CMD_SET_RANGE = 0x02;
+constexpr uint8_t CMD_SET_PACKED_RANGE = 0x03;
 constexpr uint8_t CMD_GET_INFO = 0x10;
 constexpr uint8_t CMD_GET_RANGE = 0x11;
 
@@ -99,6 +100,23 @@ void handleFrame(uint8_t cmd, const uint8_t* payload, uint16_t len) {
       }
       setPayloadRange(offset, &payload[4], count);
       sendAck(CMD_SET_RANGE);
+      break;
+    }
+
+    case CMD_SET_PACKED_RANGE: {
+      if (len < 4) {
+        sendNack(0x07);
+        break;
+      }
+      const uint16_t offset = static_cast<uint16_t>(payload[0]) | (static_cast<uint16_t>(payload[1]) << 8);
+      const uint16_t bit_count = static_cast<uint16_t>(payload[2]) | (static_cast<uint16_t>(payload[3]) << 8);
+      const uint16_t byte_count = (bit_count + 7) / 8;
+      if (len != static_cast<uint16_t>(byte_count + 4)) {
+        sendNack(0x08);
+        break;
+      }
+      setPayloadPackedRange(offset, &payload[4], bit_count);
+      sendAck(CMD_SET_PACKED_RANGE);
       break;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce UART transfer size by representing pattern bits as packed bytes instead of one byte per bit and provide a command that transmits packed bit sequences to lower transaction bandwidth by ~8x. 
- Preserve existing protocol commands and behavior while enabling an efficient packed-format path for full-frame and partial updates.

### Description
- Change internal payload storage to packed bytes (`PACKED_PAYLOAD_SIZE`) and add bit access helpers (`get/setPayloadBit`); convert default initializers to packed form and adapt all code paths to use bit helpers when reading/writing bits. 
- Add new command `CMD_SET_PACKED_RANGE (0x03)` in the serial parser with payload validation and new NACK codes, and implement `setPayloadPackedRange()` to apply packed-bit ranges while keeping `SET_ALL`/`SET_RANGE` intact. 
- Update the ESP32 display sender to synchronize display into the packed payload and switch the regular Refiz UART sender to emit packed-range frames (larger batch size, packed bytes) instead of sending unpacked bit bytes. 
- Extend the PyQt5 example (`payload_sender_pyqt5.py`) with bit-packing helpers, new UI buttons and actions for sending packed full-frame and packed-range updates, and update the protocol documentation (`PROTOCOL.md`) and baud setting accordingly. 

### Testing
- Ran `git diff --check` to catch whitespace/format issues and fixed findings; check passed. 
- Compiled the Python UI with `python3 -m py_compile SLCD_DR_Ctl/payload_sender_pyqt5.py` and it succeeded. 
- Executed local Python checks that compare the original 520-bit initializers against the new packed arrays and verified unpacking reproduces identical 520-bit contents. 
- Hardware/toolchain checks (`arduino-cli`, `idf.py`) are not available in this environment, so no device builds were performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa80437a4832393c8edaa5520e570)