### PR TITLE
Add GitHub Actions workflow to build SLCD_DR_Ctl for Arduino Nano (ATmega328P)

### DIFF
--- a/.github/workflows/build_slcd_dr_ctl.yml
+++ b/.github/workflows/build_slcd_dr_ctl.yml
@@ -1,0 +1,47 @@
+name: Build SLCD_DR_Ctl
+
+on:
+  push:
+    paths:
+      - 'SLCD_DR_Ctl/**'
+      - '.github/workflows/build_slcd_dr_ctl.yml'
+  pull_request:
+    paths:
+      - 'SLCD_DR_Ctl/**'
+      - '.github/workflows/build_slcd_dr_ctl.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Install Arduino AVR core
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install arduino:avr
+
+      - name: Compile SLCD_DR_Ctl for Arduino Nano ATmega328P
+        run: |
+          mkdir -p build/SLCD_DR_Ctl
+          arduino-cli compile \
+            --fqbn arduino:avr:nano:cpu=atmega328 \
+            --output-dir build/SLCD_DR_Ctl \
+            --export-binaries \
+            SLCD_DR_Ctl
+
+      - name: Upload SLCD_DR_Ctl build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: SLCD_DR_Ctl-arduino-nano-atmega328p
+          if-no-files-found: error
+          path: |
+            build/SLCD_DR_Ctl/*.hex
+            build/SLCD_DR_Ctl/*.elf
+            build/SLCD_DR_Ctl/*.eep


### PR DESCRIPTION
### Motivation
- Add an automated CI workflow to compile the `SLCD_DR_Ctl` Arduino sketch for the Arduino Nano (ATmega328P) and publish build artifacts so firmware can be produced from CI.

### Description
- Add `.github/workflows/build_slcd_dr_ctl.yml` which triggers on `push`, `pull_request` affecting `SLCD_DR_Ctl/**` and on `workflow_dispatch`, sets up `arduino/setup-arduino-cli@v2`, installs the `arduino:avr` core, compiles with `arduino-cli compile --fqbn arduino:avr:nano:cpu=atmega328 --output-dir build/SLCD_DR_Ctl --export-binaries SLCD_DR_Ctl`, and uploads resulting `*.hex`, `*.elf`, and `*.eep` files via `actions/upload-artifact@v4`.

### Testing
- Ran `git diff --check` which completed without reported issues. 
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_slcd_dr_ctl.yml"); puts "yaml ok"'` which returned `yaml ok` indicating valid YAML. 
- Attempted a local Arduino CLI install/compile in this environment but the steps failed due to external HTTP 403 errors when fetching remote resources, so a full compile was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed6cde5208323b2173a7dd41346c0)