### PR TITLE
Add REFIZ clock button time control

### DIFF
--- a/ESP32/Digifiz/main/mfa.c
+++ b/ESP32/Digifiz/main/mfa.c
@@ -5,6 +5,7 @@
 #include "driver/gpio.h"
 #include "adc.h"
 #include <time.h>
+#include <sys/time.h>
 
 uint8_t uptimeDisplayEnabled = 0;
 uint8_t mfaMemorySelected = 0;
@@ -13,11 +14,19 @@ uint8_t bMFAMode = 0;
 uint8_t bMFABlock = 0;
 uint8_t bMFAReset = 0;
 uint8_t bMFASensor = 0;
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+uint8_t bClockMinutes = 0;
+uint8_t bClockHours = 0;
+#endif
 
 uint8_t prevMFAMode = 0;
 uint8_t prevMFABlock = 0;
 uint8_t prevMFAReset = 0;
 uint8_t prevMFASensor = 0;
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+uint8_t prevClockMinutes = 0;
+uint8_t prevClockHours = 0;
+#endif
 
 uint8_t sensorPressed = 0;
 uint32_t pressSensorTime = 0;
@@ -26,6 +35,24 @@ extern int16_t seconds_block1;
 extern int16_t seconds_block2;
 extern struct tm saved_time1;
 extern struct tm saved_time2;
+
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+static void addSystemTime(int hours, int minutes)
+{
+    time_t current_time_t;
+    struct tm current_time;
+
+    time(&current_time_t);
+    localtime_r(&current_time_t, &current_time);
+
+    current_time.tm_hour += hours;
+    current_time.tm_min += minutes;
+
+    current_time_t = mktime(&current_time);
+    struct timeval tv = { .tv_sec = current_time_t, .tv_usec = 0 };
+    settimeofday(&tv, NULL);
+}
+#endif
 // Initialize the MFA (Multi-Function Display)
 void initMFA() {
     // Implementation placeholder
@@ -48,6 +75,10 @@ void processMFA()
     bMFAMode = digifiz_reg_in.mfaMode;
     bMFABlock = digifiz_reg_in.mfaBlock;
     bMFAReset = digifiz_reg_in.mfaReset;
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+    bClockMinutes = digifiz_reg_in.clockMinutes;
+    bClockHours = digifiz_reg_in.clockHours;
+#endif
     if (digifiz_parameters.signalOptions_enable_touch_sensor.value)
     {
         bMFASensor = gpio_get_level(TOUCH_PIN);
@@ -64,6 +95,10 @@ void processMFA()
         prevMFABlock = bMFABlock;
         prevMFAReset = bMFAReset;
         prevMFASensor = bMFASensor;
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+        prevClockMinutes = bClockMinutes;
+        prevClockHours = bClockHours;
+#endif
         return;
     }
 
@@ -109,10 +144,27 @@ void processMFA()
             pressMFASensorSuperSuperLong();
     }
 #endif
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+    if ((bClockMinutes == 0) && (prevClockMinutes == 1))
+    {
+        ESP_LOGI(LOG_TAG,  "Clock minutes increment");
+        addSystemTime(0, 1);
+    }
+
+    if ((bClockHours == 0) && (prevClockHours == 1))
+    {
+        ESP_LOGI(LOG_TAG,  "Clock hours increment");
+        addSystemTime(1, 0);
+    }
+#endif
     prevMFAMode = bMFAMode;
     prevMFABlock = bMFABlock;
     prevMFAReset = bMFAReset;
     prevMFASensor = bMFASensor;
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+    prevClockMinutes = bClockMinutes;
+    prevClockHours = bClockHours;
+#endif
 }
 
 // Simulate pressing MFA mode button


### PR DESCRIPTION
### Motivation
- Support REFIZ display clock adjustment via hardware buttons by monitoring `clockMinutes` and `clockHours` signals in the input register and applying changes to system time when their input falls. 
- Keep the feature REFIZ-specific behind `DIGIFIZ_REFIZ_DISPLAY` guards so other display variants are unaffected.

### Description
- Added `#include <sys/time.h>` and REFIZ-only variables `bClockMinutes`, `bClockHours`, `prevClockMinutes`, and `prevClockHours` to `ESP32/Digifiz/main/mfa.c` to track current and previous states. 
- Implemented a REFIZ-only helper `addSystemTime(int hours, int minutes)` which adjusts system time via `mktime()` and `settimeofday()`. 
- Updated `processMFA()` to read `digifiz_reg_in.clockMinutes` and `digifiz_reg_in.clockHours`, ignore startup transients, detect falling edges (`1 -> 0`) on those signals, and call `addSystemTime(0,1)` or `addSystemTime(1,0)` accordingly; all changes are wrapped in `#ifdef DIGIFIZ_REFIZ_DISPLAY`.

### Testing
- Attempted to build with `cd ESP32/Digifiz && idf.py build`, but the build could not be executed in this environment because `idf.py` is not available, so no firmware build or runtime tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d3791ea88323988a861311760365)