### PR TITLE
Add ReFIZ segment diagnostic controls to web UI

### DIFF
--- a/ESP32/Digifiz/main/data/digifiz_ws_connect.html
+++ b/ESP32/Digifiz/main/data/digifiz_ws_connect.html
@@ -467,6 +467,7 @@
 	<a href="#" onclick="selTab(event,'Control')" class="tablinks">Control</a>
 	<a href="#" onclick="selTab(event,'Settings')" class="tablinks">Settings</a>
 	<a href="#" onclick="selTab(event,'Colors')" class="tablinks">Colors</a>
+	<a href="#" onclick="selTab(event,'Diagnostics')" class="tablinks">Diagnostics</a>
 	<a href="#" onclick="selTab(event,'About')" class="tablinks">About</a>
 	<a href="javascript:void(0);" class="icon" onclick="myFunction()">
 		<span class="hamburger"></span>
@@ -575,6 +576,23 @@
     			<button class="cl01" type="button" id="importScheme">Import from File</button>
 			</div>
 			<input type="file" id="importFile" style="display: none">
+		</div>
+	</div>
+</div>
+
+<div id="Diagnostics" class="tabcontent">
+	<div class="tci">
+		<div class="hdr">ReFIZ segment diagnostics</div>
+		<div class="cl1">
+			<p style="font-size: 1rem;">Diagnostic mode freezes the LCD pattern. Select each logical segment that should be on, then apply the pattern.</p>
+			<label><input type="checkbox" id="refizDiagnosticEnabled"> Enable diagnostic mode</label>
+			<div class="mfa-buttons" style="margin: 10px 0;">
+				<button type="button" id="refizAllOn">Select all</button>
+				<button type="button" id="refizAllOff">Clear all</button>
+				<button type="button" id="refizApply">Apply pattern</button>
+			</div>
+			<div id="refizSegments" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(72px,1fr));gap:4px;text-align:left;"></div>
+			<div id="refizDiagnosticStatus" role="status" style="margin-top:10px;"></div>
 		</div>
 	</div>
 </div>
@@ -924,6 +942,45 @@ function myFunction() {
   }
 }
 document.getElementById("defaultTab").click();
+</script>
+
+<script>
+const refizSegments = document.getElementById('refizSegments');
+for (let segment = 0; segment <= 260; segment++) {
+	const label = document.createElement('label');
+	const input = document.createElement('input');
+	input.type = 'checkbox';
+	input.dataset.segment = segment;
+	label.append(input, ` ${segment}`);
+	refizSegments.appendChild(label);
+}
+
+function setAllRefizSegments(checked) {
+	refizSegments.querySelectorAll('input').forEach(input => input.checked = checked);
+}
+
+document.getElementById('refizAllOn').addEventListener('click', () => setAllRefizSegments(true));
+document.getElementById('refizAllOff').addEventListener('click', () => setAllRefizSegments(false));
+document.getElementById('refizApply').addEventListener('click', async () => {
+	const status = document.getElementById('refizDiagnosticStatus');
+	const segments = Array.from(refizSegments.querySelectorAll('input:checked'),
+		input => Number(input.dataset.segment));
+	status.textContent = 'Applying…';
+	try {
+		const response = await fetch('/refiz_diagnostic', {
+			method: 'POST',
+			headers: {'Content-Type': 'application/json'},
+			body: JSON.stringify({
+				enabled: document.getElementById('refizDiagnosticEnabled').checked,
+				segments
+			})
+		});
+		if (!response.ok) throw new Error(await response.text());
+		status.textContent = `Applied ${segments.length} enabled segment(s).`;
+	} catch (error) {
+		status.textContent = `Could not apply diagnostics: ${error.message}`;
+	}
+});
 </script>
 
 <script>

--- a/ESP32/Digifiz/main/digifiz_ws_server.c
+++ b/ESP32/Digifiz/main/digifiz_ws_server.c
@@ -30,6 +30,65 @@ esp_err_t digifiz_register_uri_handler(httpd_handle_t server);
 esp_err_t update_post_handler(httpd_req_t *req);
 static esp_err_t echo_handler(httpd_req_t *req);
 static esp_err_t params_get_handler(httpd_req_t *req);
+
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+static esp_err_t refiz_diagnostic_post_handler(httpd_req_t *req)
+{
+    char buf[1536];
+    if (req->content_len <= 0 || req->content_len >= sizeof(buf)) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request size");
+        return ESP_FAIL;
+    }
+
+    int received = 0;
+    while (received < req->content_len) {
+        int chunk = httpd_req_recv(req, buf + received, req->content_len - received);
+        if (chunk <= 0) {
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to receive data");
+            return ESP_FAIL;
+        }
+        received += chunk;
+    }
+    buf[received] = '\0';
+
+    cJSON *json = cJSON_Parse(buf);
+    cJSON *enabled = json ? cJSON_GetObjectItemCaseSensitive(json, "enabled") : NULL;
+    cJSON *segments = json ? cJSON_GetObjectItemCaseSensitive(json, "segments") : NULL;
+    if (!cJSON_IsBool(enabled) || !cJSON_IsArray(segments) ||
+        cJSON_GetArraySize(segments) > 261) {
+        cJSON_Delete(json);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Expected enabled and segments");
+        return ESP_FAIL;
+    }
+
+    uint16_t selected[261];
+    size_t selected_count = 0;
+    cJSON *item = NULL;
+    cJSON_ArrayForEach(item, segments) {
+        if (!cJSON_IsNumber(item) || item->valuedouble < 0 ||
+            item->valuedouble > 260 || item->valuedouble != item->valueint) {
+            cJSON_Delete(json);
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid segment number");
+            return ESP_FAIL;
+        }
+        selected[selected_count++] = (uint16_t)item->valueint;
+    }
+
+    refiz_diagnostic_set_segments(selected, selected_count);
+    refiz_diagnostic_set_enabled(cJSON_IsTrue(enabled));
+    cJSON_Delete(json);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"status\":\"ok\"}");
+    return ESP_OK;
+}
+
+static const httpd_uri_t refiz_diagnostic_post = {
+    .uri = "/refiz_diagnostic",
+    .method = HTTP_POST,
+    .handler = refiz_diagnostic_post_handler,
+    .user_ctx = NULL
+};
+#endif
 /*
  * This handler echos back the received ws data
  * and triggers an async send if certain message received
@@ -571,6 +630,11 @@ esp_err_t digifiz_register_uri_handler(httpd_handle_t server)
     if (ret)
         goto _ret;
     ret = httpd_register_uri_handler(server, &set_color_scheme);
+    if (ret)
+        goto _ret;
+#ifdef DIGIFIZ_REFIZ_DISPLAY
+    ret = httpd_register_uri_handler(server, &refiz_diagnostic_post);
+#endif
     if (ret)
         goto _ret;
 _ret:

--- a/ESP32/Digifiz/main/display_next.h
+++ b/ESP32/Digifiz/main/display_next.h
@@ -223,6 +223,12 @@ void fireDigifiz();
 void refiz_uart_sender_init(void);
 void refiz_uart_sender_trigger(void);
 
+/** Enable or disable the ReFIZ static segment diagnostic override. */
+void refiz_diagnostic_set_enabled(bool enabled);
+
+/** Replace the diagnostic segment mask (logical segment numbers 0..260). */
+void refiz_diagnostic_set_segments(const uint16_t *segments, size_t segment_count);
+
 void setOilIndicator(bool onoff);
 void setBrakesIndicator(bool onoff);
 void setHeatLightsIndicator(bool onoff);

--- a/ESP32/Digifiz/main/display_refiz.c
+++ b/ESP32/Digifiz/main/display_refiz.c
@@ -103,6 +103,8 @@ static const uint8_t refiz_default_payload[PACKED_PAYLOAD_SIZE] = {
 
 static uint8_t bool_data_payload[PACKED_PAYLOAD_SIZE];
 static bool refiz_uart_ready = false;
+static bool refiz_diagnostic_enabled = false;
+static uint8_t refiz_diagnostic_segments[(261 + 7) / 8];
 
 static const uint8_t refiz_orig_digit_patterns[10] = {
     0b00111111, 0b00100001, 0b01011011, 0b01110011, 0b01100101,
@@ -217,6 +219,21 @@ static void refiz_sync_payload_from_display(void)
 
     memcpy(bool_data_payload, refiz_default_payload, sizeof(bool_data_payload));
 
+    if (refiz_diagnostic_enabled)
+    {
+        /* Payload bits 0..2 are controller housekeeping; logical LCD segment
+         * zero starts at payload bit three. */
+        memset(bool_data_payload + 1, 0, REFIZ_UART_BATCH_BYTES - 1);
+        bool_data_payload[0] &= 0x07;
+        for (uint16_t segment = 0; segment < 261; segment++)
+        {
+            uint8_t enabled = refiz_diagnostic_segments[segment >> 3] &
+                              (1U << (segment & 0x07));
+            refiz_payload_set_bit(segment + 3, enabled);
+        }
+        return;
+    }
+
     refiz_put_digit(mileage_segments[0], display.mileage_digit_1);
     refiz_put_digit(mileage_segments[1], display.mileage_digit_2);
     refiz_put_digit(mileage_segments[2], display.mileage_digit_3);
@@ -274,6 +291,24 @@ static void refiz_sync_payload_from_display(void)
         refiz_payload_set_bit(refiz_rpm_segments[i] + 3, (i < rpm_segments_on) ? 1 : 0);
     }
     //refiz_payload_set_bit(refiz_rpm_segments[0] + 3, 1);
+}
+
+void refiz_diagnostic_set_enabled(bool enabled)
+{
+    refiz_diagnostic_enabled = enabled;
+}
+
+void refiz_diagnostic_set_segments(const uint16_t *segments, size_t segment_count)
+{
+    memset(refiz_diagnostic_segments, 0, sizeof(refiz_diagnostic_segments));
+    for (size_t i = 0; i < segment_count; i++)
+    {
+        if (segments[i] < 261)
+        {
+            refiz_diagnostic_segments[segments[i] >> 3] |=
+                1U << (segments[i] & 0x07);
+        }
+    }
 }
 
 void refiz_uart_sender_init(void)


### PR DESCRIPTION
### Motivation

- Provide a web-driven diagnostic mode for ReFIZ so developers can statically select which LCD segments are forced on/off for troubleshooting without changing existing SLCD_DR_Ctl code or protocol. 

### Description

- Add a new `Diagnostics` tab to the web UI (`ESP32/Digifiz/main/data/digifiz_ws_connect.html`) with checkboxes for logical segments `0..260`, `Select all`/`Clear all` buttons, diagnostic enable toggle, and an `Apply` action that posts the selection. 
- Implement a validated HTTP endpoint `POST /refiz_diagnostic` in `digifiz_ws_server.c` that handles partial reads, validates segment numbers, and accepts `{ enabled: boolean, segments: [..] }` JSON; it is registered only when `DIGIFIZ_REFIZ_DISPLAY` is defined. 
- Add public APIs in `display_next.h`: `refiz_diagnostic_set_enabled(bool)` and `refiz_diagnostic_set_segments(...)`, and implement them in `display_refiz.c` to maintain a packed diagnostic segment mask. 
- When diagnostic mode is enabled the ReFIZ payload rendering is overridden in `refiz_sync_payload_from_display()` to use the diagnostic mask (preserving controller housekeeping bits) and the existing packed-range UART sender continues to transmit the resulting payload; normal rendering resumes when disabled. 
- The change uses the existing websocket/HTTP server and `cJSON` for parsing, and intentionally does not modify `SLCD_DR_Ctl` as requested. 

### Testing

- Ran embedded JavaScript syntax validation with `node --check` on the extracted scripts and it passed. 
- Ran HTML/JS source assertions (presence of `id="Diagnostics"`, `refizDiagnosticEnabled`, `segment <= 260`, and `fetch('/refiz_diagnostic'`) and they passed. 
- Ran repository checks including `git diff --check` and found no issues. 
- Attempted `ninja -C build` to build the firmware but it is not runnable in this environment because the checked-in `build` directory has no `build.ninja` and ESP-IDF tooling is unavailable (build not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eb3024e2c8323a12fe0cbf50e6a55)