### PR TITLE
Fix ESP32 blinking dot behavior

### DIFF
--- a/ESP32/Digifiz/main/display_next.c
+++ b/ESP32/Digifiz/main/display_next.c
@@ -832,7 +832,16 @@ void setCoolantData(uint16_t data) {
 
 // Set the dot status
 void setDot(bool value) {
-    // Implementation placeholder
+    bool dot_on = !digifiz_parameters.displayDot.value || value;
+
+    display.clock_dot = dot_on ? 0b11 : 0b00;
+
+    if (digifiz_parameters.mfaState.value == MFA_STATE_TRIP_DURATION) {
+        if (dot_on)
+            display.mfa_dots |= 0b011;
+        else
+            display.mfa_dots &= ~0b011;
+    }
 }
 
 // Set the floating dot status

--- a/ESP32/Digifiz/main/main.c
+++ b/ESP32/Digifiz/main/main.c
@@ -229,7 +229,6 @@ void digifizLoop(void *pvParameters) {
         setMFABlock(digifiz_parameters.mfaBlock.value ? 0 : 1); //in display h
         displayMFAClock();
         displayMFAType(uptimeDisplayEnabled ? 6 : digifiz_parameters.mfaState.value);
-        setDot(false);
         //printf("Reg in: %u %u %u\n", digifiz_reg_in.bytes[0], digifiz_reg_in.bytes[1], digifiz_reg_in.mfaReset);
         xSemaphoreGive(displayMutex); // Give back the mutex
         
@@ -475,6 +474,7 @@ void displayUpdate(void *pvParameters) {
         fireDigifiz();
         setMFAType(uptimeDisplayEnabled ? 6 : digifiz_parameters.mfaState.value);
         processMFA();
+        setDot((millis() % 1000U) < 500U);
         regout_all(digifiz_reg_out.byte);
         regin_read(digifiz_reg_in.bytes);
         //protocolParse();


### PR DESCRIPTION
### Motivation
- The existing `displayDot` parameter was defined but never applied, so the display clock/trip dots did not blink as configured.
- The blink should be a 1 second period (approximately 500 ms on / 500 ms off) and reuse existing display tasks rather than creating a new task.

### Description
- Implemented `setDot(bool)` in `ESP32/Digifiz/main/display_next.c` to honor `digifiz_parameters.displayDot.value` and update `display.clock_dot` accordingly using `bool dot_on = !digifiz_parameters.displayDot.value || value;`.
- When the MFA state is `MFA_STATE_TRIP_DURATION`, `setDot` now also updates `display.mfa_dots` so trip-duration dots follow the same blink/always-on behaviour.
- Drive the blink from the existing 32 Hz display update loop by calling `setDot((millis() % 1000U) < 500U);` in `ESP32/Digifiz/main/main.c` to produce a 500 ms on / 500 ms off cycle.
- Removed the previous unconditional `setDot(false)` call in the one-second loop to avoid overwriting the blink state.

### Testing
- Ran `git diff --check` which produced no check failures.
- Ran `python3 -m pytest -q` which completed successfully but discovered no tests.
- Verified the two source files modified were staged and committed locally (`ESP32/Digifiz/main/display_next.c` and `ESP32/Digifiz/main/main.c`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eb43b94fc8323ab4500e97085dbbb)