### PR TITLE
Configure the speed display update cadence

### DIFF
--- a/A2560_BoardR2/Digifiz/Digifiz.ino
+++ b/A2560_BoardR2/Digifiz/Digifiz.ino
@@ -31,7 +31,7 @@ extern uint8_t tr_status;
 #endif
 
 int saveParametersCounter = 0;
-uint16_t displaySpeedCnt = 0;
+uint16_t displaySpeedCounter = 0;
 //Speed related data
 uint32_t spd_m = 0;
 float spd_m_speedometer = 0;
@@ -158,7 +158,8 @@ ISR(TIMER4_COMPA_vect)
 {
   if (testMode)
   {
-    if (displaySpeedCnt==3) // 2 Hz loop(as on original Digifiz)  
+    // Keep test-mode values in step with the configured speed display cadence.
+    if ((displaySpeedCounter + 1) >= digifiz_parameters.speedDisplayUpdateDivider.value)
     {
       averageRPM+=50;
       if (averageRPM>8000)
@@ -257,14 +258,15 @@ ISR(TIMER4_COMPA_vect)
 #endif  
   }
 
-  displaySpeedCnt++;
-  if (displaySpeedCnt==4) // 2 Hz loop(as on original Digifiz)  
+  displaySpeedCounter++;
+  // The divider defaults to 4, matching the original Digifiz's 2 Hz update rate.
+  if (displaySpeedCounter >= digifiz_parameters.speedDisplayUpdateDivider.value)
   {
     setSpeedometerData((uint16_t)spd_m_speedometer);
     //setSpeedometerData(digifiz_parameters.mfaState.value);
     current_averageSpeed1 += (spd_m_speedometer-current_averageSpeed1)*0.01;
     current_averageSpeed2 += (spd_m_speedometer-current_averageSpeed2)*0.01;
-    displaySpeedCnt = 0;
+    displaySpeedCounter = 0;
   }
   if (getBuzzerEnabled())
   {

--- a/A2560_BoardR2/Digifiz/params_list.h
+++ b/A2560_BoardR2/Digifiz/params_list.h
@@ -452,6 +452,15 @@ extern "C" {
     ) \
     PARAM(  \
         U16, \
+        speedDisplayUpdateDivider, \
+        .p_name = "Speed display update divider", \
+        .p_info = "Number of 8 Hz main-loop cycles between displayed speed updates",\
+        .value = 4, \
+        .min = 1, \
+        .max = 80, \
+    ) \
+    PARAM(  \
+        U16, \
         coolantThermistorPullUpRes, \
         .p_name = "", \
         .p_info = "",\

--- a/ESP32/Digifiz/main/main.c
+++ b/ESP32/Digifiz/main/main.c
@@ -48,7 +48,7 @@
 
 int i = 0;
 int saveParametersCounter = 0;
-uint16_t displaySpeedCnt = 0;
+uint16_t displaySpeedCounter = 0;
 //Speed related data
 uint32_t spd_m = 0;
 float spd_m_speedometer = 0;
@@ -326,8 +326,9 @@ void displayUpdate(void *pvParameters) {
         averageRPM = 3000.0f;
 #endif
 
-        displaySpeedCnt++;
-        if (displaySpeedCnt==16) // 2 Hz loop(as on original Digifiz)
+        displaySpeedCounter++;
+        // The divider defaults to 16, matching the original Digifiz's 2 Hz update rate.
+        if (displaySpeedCounter >= digifiz_parameters.speedDisplayUpdateDivider.value)
         {
             setSpeedometerData((uint16_t)spd_m_speedometer);
             current_averageSpeed += (spd_m_speedometer-current_averageSpeed)*0.01;
@@ -341,7 +342,7 @@ void displayUpdate(void *pvParameters) {
                     rpm=0;
             }
 
-            displaySpeedCnt = 0;
+            displaySpeedCounter = 0;
         }
 
         if (!showGearInRefuel && gear_blink_toggles>0) {

--- a/ESP32/Digifiz/main/params_list.h
+++ b/ESP32/Digifiz/main/params_list.h
@@ -779,6 +779,15 @@ extern "C" {
     ) \
     PARAM(  \
         U16, \
+        speedDisplayUpdateDivider, \
+        .p_name = "Speed display update divider", \
+        .p_info = "Number of 32 Hz main-loop cycles between displayed speed updates",\
+        .value = 16, \
+        .min = 1, \
+        .max = 320, \
+    ) \
+    PARAM(  \
+        U16, \
         coolantThermistorPullUpRes, \
         .p_name = "Coolant pull-up", \
         .p_info = "Pull-up resistance for coolant temperature sensor",\


### PR DESCRIPTION
### Motivation
- Provide an adjustable cadence for how often the displayed vehicle speed is updated so the update frequency can be tuned without changing code.
- Replace the hard-coded display counter and clarify naming to improve readability and maintainability.

### Description
- Add a persisted parameter `speedDisplayUpdateDivider` to `params_list.h` for both ESP32 and A2560 targets with sensible defaults and ranges (`ESP32` default `16` range `1..320`, `A2560` default `4` range `1..80`).
- Rename `displaySpeedCnt` to `displaySpeedCounter` across ESP32 (`main.c`) and A2560 (`Digifiz.ino`) sources and update comments for clarity.
- Replace hard-coded checks (`== 16`, `== 4`) with divider-driven checks using `digifiz_parameters.speedDisplayUpdateDivider.value` and reset the counter when the divider is reached.
- Keep test-mode speed generation synchronized with the configured divider on the A2560 so simulated/test values follow the selected display cadence.

### Testing
- Ran `git diff --check` and it completed with no whitespace/patch errors.
- Verified updated symbols and references with `rg -n "displaySpeedCnt|speedDisplayUpdateDivider|displaySpeedCounter"` and confirmed the changes are present in the intended files.
- Attempted to run local firmware builds but `idf.py` and `arduino-cli` were not present in the environment, so compilation was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eb5ccdcf8832385f3f8ac4e2f6de9)