### PR TITLE
Add configurable inversion for the 0.3 bar oil input

### DIFF
--- a/ESP32/Digifiz/main/emegrency.c
+++ b/ESP32/Digifiz/main/emegrency.c
@@ -34,7 +34,9 @@ uint8_t processOilPressure(int mRPM)
 {
   //TODO check and implement
     emergency_state = 0;
-    if (digifiz_reg_in.oil03==0)
+    const uint8_t oil03_input = digifiz_reg_in.oil03 ? 1 : 0;
+    const uint8_t invert_oil03_input = digifiz_parameters.option_invert_oil03_input.value ? 1 : 0;
+    if ((oil03_input ^ invert_oil03_input) == 0)
     {
         emergency_state = 1;
     }

--- a/ESP32/Digifiz/main/params_list.h
+++ b/ESP32/Digifiz/main/params_list.h
@@ -123,6 +123,14 @@ extern "C" {
     ) \
     PARAM(  \
         U8, \
+        option_invert_oil03_input, \
+        .p_name = "Invert 0.3 bar input", \
+        .p_info = "Invert the 0.3 bar oil pressure input (1 is treated as 0 and 0 as 1)",\
+        .value = 0, \
+        .max = 1, \
+    ) \
+    PARAM(  \
+        U8, \
         rpmOptions_redline_segments, \
         .p_name = "Redline segments", \
         .p_info = "Redline segments number",\


### PR DESCRIPTION
### Motivation
- Provide an option to invert the 0.3 bar oil-pressure input signal so boards with inverted wiring or sensors can treat `1` as `0` and `0` as `1` without changing hardware.

### Description
- Add a persisted boolean parameter `option_invert_oil03_input` (default `0`) to `PARAM_LIST` to control inversion.
- Apply the option in `processOilPressure()` by computing the effective input (`oil03_input ^ invert_oil03_input`) before evaluating the low-pressure warning.

### Testing
- Ran `git diff --check` and a `python3` script that verifies the four combinations of raw input and inversion produce the expected warning states, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fab5c98a4832390314f36a1b7fdb3)