### PR TITLE
Report ESP32 reset reason in protocol help

### DIFF
--- a/ESP32/Digifiz/main/protocol.c
+++ b/ESP32/Digifiz/main/protocol.c
@@ -7,6 +7,7 @@
 #include "digifiz_time.h"
 #include "vehicle_data.h"
 #include "display_next.h"
+#include "esp_system.h"
 #include <stdlib.h>
 #include <ctype.h>
 
@@ -216,7 +217,11 @@ static void printStatusJSON()
 
 static void printHelp()
 {
+  esp_reset_reason_t reason = esp_reset_reason();
+
   printLnCString("Digifiz Replica by PHOL-LABS.\n");
+  printLnCString("Reset reason:\n");
+  printLnUINT32((uint32_t)reason);
   printLnCString("Your dashboard is:\n");
   if (digifiz_parameters.option_mfa_manufacturer.value)
     printLnCString("MFA ON\n");


### PR DESCRIPTION
### Motivation
- Expose the ESP32 reset reason when users invoke the protocol `help` command to aid debugging of wake/reset scenarios.

### Description
- Add `#include "esp_system.h"` and call `esp_reset_reason()` inside `printHelp()` to obtain the reset reason and emit it via `printLnUINT32((uint32_t)reason)`.

### Testing
- Ran `git -c core.whitespace=cr-at-eol diff --check` which passed; running `python3 -m pytest ESP32/Digifiz/pytest_main.py -q` failed to collect tests because `pytest_embedded_idf` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f2a6739808323be9c19d0c7e0c618)