### PR TITLE
Add safe display ramp-up and clock recovery across power reset

### DIFF
--- a/ESP32/Digifiz/main/device_sleep.c
+++ b/ESP32/Digifiz/main/device_sleep.c
@@ -7,7 +7,9 @@
 #include "setup.h"
 #include "display_next.h"
 #include "digifiz_watchdog.h"
+#include "nvs.h"
 #include <stdio.h>
+#include <sys/time.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -16,10 +18,69 @@
 
 #define SLEEP_PIN GPIO_NUM_10
 #define POWER_OUT_PIN GPIO_NUM_47
+#define POWER_TIME_NAMESPACE "power_backup"
+#define POWER_TIME_SECONDS_KEY "time_seconds"
+#define POWER_TIME_USECONDS_KEY "time_useconds"
 
 
 const int ext_wakeup_pin_1 = SLEEP_PIN;
 const uint64_t ext_wakeup_pin_1_mask = 1ULL << SLEEP_PIN;
+
+static void save_power_time(void)
+{
+    struct timeval now;
+    nvs_handle_t handle;
+
+    gettimeofday(&now, NULL);
+    esp_err_t err = nvs_open(POWER_TIME_NAMESPACE, NVS_READWRITE, &handle);
+    if (err == ESP_OK) {
+        err = nvs_set_i64(handle, POWER_TIME_SECONDS_KEY, (int64_t)now.tv_sec);
+        if (err == ESP_OK) {
+            err = nvs_set_i32(handle, POWER_TIME_USECONDS_KEY, (int32_t)now.tv_usec);
+        }
+        if (err == ESP_OK) {
+            err = nvs_commit(handle);
+        }
+        nvs_close(handle);
+    }
+
+    if (err != ESP_OK) {
+        ESP_LOGE(LOG_TAG, "Failed to back up time before power enable: %s", esp_err_to_name(err));
+    }
+}
+
+void device_restore_power_time(void)
+{
+    nvs_handle_t handle;
+    int64_t seconds = 0;
+    int32_t useconds = 0;
+    esp_err_t err = nvs_open(POWER_TIME_NAMESPACE, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        ESP_LOGW(LOG_TAG, "Could not open power time backup: %s", esp_err_to_name(err));
+        return;
+    }
+
+    esp_err_t seconds_err = nvs_get_i64(handle, POWER_TIME_SECONDS_KEY, &seconds);
+    esp_err_t useconds_err = nvs_get_i32(handle, POWER_TIME_USECONDS_KEY, &useconds);
+    if (seconds_err == ESP_OK && useconds_err == ESP_OK && seconds != 0) {
+        const struct timeval restored = {
+            .tv_sec = (time_t)seconds,
+            .tv_usec = (suseconds_t)useconds,
+        };
+        if (settimeofday(&restored, NULL) == 0) {
+            ESP_LOGI(LOG_TAG, "Restored time saved before POWER_OUT reset");
+            nvs_set_i64(handle, POWER_TIME_SECONDS_KEY, 0);
+            nvs_set_i32(handle, POWER_TIME_USECONDS_KEY, 0);
+            err = nvs_commit(handle);
+            if (err != ESP_OK) {
+                ESP_LOGE(LOG_TAG, "Failed to clear restored power time: %s", esp_err_to_name(err));
+            }
+        } else {
+            ESP_LOGE(LOG_TAG, "Failed to restore time saved before POWER_OUT reset");
+        }
+    }
+    nvs_close(handle);
+}
 
 static void deep_sleep_task(void *args)
 {
@@ -112,7 +173,7 @@ bool device_sleep_check() {
     }
     else
     {
-        gpio_set_level(POWER_OUT_PIN, 1);
+        device_power_enable(true);
     }
     return sleepMode;
 }
@@ -121,6 +182,9 @@ void device_power_enable(bool enable)
 {
     if (enable)
     {
+        if (gpio_get_level(POWER_OUT_PIN) == 0) {
+            save_power_time();
+        }
         gpio_set_level(POWER_OUT_PIN, 1);
     }
     else

--- a/ESP32/Digifiz/main/device_sleep.h
+++ b/ESP32/Digifiz/main/device_sleep.h
@@ -38,6 +38,14 @@ void device_sleep_dump();
  */
 void device_power_enable(bool enable);
 
+/**
+ * @brief Restore a time saved immediately before POWER_OUT was enabled.
+ *
+ * This must be called after NVS initialization and before enabling POWER_OUT.
+ * A successfully consumed backup is cleared so it cannot be reused.
+ */
+void device_restore_power_time(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ESP32/Digifiz/main/display_next.c
+++ b/ESP32/Digifiz/main/display_next.c
@@ -8,6 +8,7 @@
 #include "params.h"
 #include "led_effects.h"
 #include "millis.h"
+#include "esp_timer.h"
 
 #define TAG "display_next"
 #define SCRIPT_KEY "display_next_script"
@@ -16,11 +17,15 @@ uint8_t selectedBrightness = 20;
 uint32_t mRPMData = 4000;
 uint8_t backlightOff = 0;
 
-uint8_t backlightLevel = 30;
+uint8_t backlightLevel = 0;
 
 DigifizNextDisplay display;
 static led_strip_handle_t led_strip;
-float brightnessFiltered = 6.0f;
+float brightnessFiltered = 0.0f;
+static int64_t brightnessRampStartUs;
+static bool brightnessRampComplete;
+
+#define BRIGHTNESS_STARTUP_RAMP_US 1000000LL
 static led_effect_state_t effect_state;
 
 static uint16_t l_spd_m = 0;
@@ -1166,6 +1171,28 @@ void setMFABlock(uint8_t block) {
 
 // Set the brightness level
 void setBrightness(uint8_t levels) {
+    const int64_t now = esp_timer_get_time();
+    if (brightnessRampStartUs == 0) {
+        brightnessRampStartUs = now;
+    }
+
+    const int64_t rampElapsedUs = now - brightnessRampStartUs;
+    if (!brightnessRampComplete && rampElapsedUs < BRIGHTNESS_STARTUP_RAMP_US) {
+        /* Always start at zero after boot/wake and reach the requested level in
+         * one second.  This limits the display inrush independently of the
+         * user-configurable brightness smoothing speed. */
+        brightnessFiltered = ((float)levels * (float)rampElapsedUs) /
+                             (float)BRIGHTNESS_STARTUP_RAMP_US;
+        backlightLevel = (uint8_t)brightnessFiltered;
+        return;
+    }
+    if (!brightnessRampComplete) {
+        brightnessFiltered = (float)levels;
+        backlightLevel = levels;
+        brightnessRampComplete = true;
+        return;
+    }
+
     float coef = ((float)digifiz_parameters.brightnessSpeed.value)/100.0f;
     brightnessFiltered += coef*((float)levels-brightnessFiltered);
     backlightLevel = (uint8_t)brightnessFiltered;
@@ -1175,6 +1202,8 @@ void resetBrightness()
 {
     brightnessFiltered = 0.0f;
     backlightLevel = 0;
+    brightnessRampStartUs = esp_timer_get_time();
+    brightnessRampComplete = false;
 }
 
 // Set the refuel sign status

--- a/ESP32/Digifiz/main/main.c
+++ b/ESP32/Digifiz/main/main.c
@@ -598,6 +598,7 @@ void on_cpu_1(void *pvParameters)
     displayMutex = xSemaphoreCreateMutex(); // Create the mutex
     initAndCheckRTC();
     initEEPROM(); //Start memory container
+    device_restore_power_time();
     initGearEstimator();
     initADC();
     initDisplay();


### PR DESCRIPTION
### Motivation
- Prevent large inrush/current surges on boot or wake by ensuring display/backlight brightness always starts at zero and ramps to the requested level within one second.
- Preserve and recover wall-clock time across a full MCU power cycle caused by toggling the backlight power stage so the system clock can be restored after startup.

### Description
- Implemented a one-second linear startup/wake brightness ramp in `ESP32/Digifiz/main/display_next.c` by initializing `brightnessFiltered` and `backlightLevel` to zero, adding `esp_timer` based ramp logic, and restarting the ramp in `resetBrightness()`; introduced `BRIGHTNESS_STARTUP_RAMP_US` and a `brightnessRampComplete` flag.
- Added NVS-backed time backup in `ESP32/Digifiz/main/device_sleep.c` using new keys under namespace `"power_backup"`, with `save_power_time()` called just before the `POWER_OUT_PIN` transitions low->high and `device_restore_power_time()` to restore and consume the saved time at boot.
- Routed wake-time power enabling through `device_power_enable()` (used in `device_sleep_check()`) so the backup is always saved before enabling `POWER_OUT_PIN`, and added the `device_restore_power_time()` prototype to `ESP32/Digifiz/main/device_sleep.h` for documentation and proper startup ordering.
- Invoke `device_restore_power_time()` early in startup (after `initEEPROM()`) in `ESP32/Digifiz/main/main.c` so a valid backup is consumed and cleared before normal operation.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it returned clean results.
- Attempted a local build with `cmake --build build -j2` but it failed due to missing CMake cache / ESP-IDF not configured in the execution environment (`IDF_PATH` unset), so a full build/test on-target could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70523511008323b2912212a92018c7)